### PR TITLE
Fixes #17 by disabling posix mode.

### DIFF
--- a/bin/ebash
+++ b/bin/ebash
@@ -60,7 +60,6 @@ for arg in "$@" ; do
     fi
 done
 
-
 : ${EBASH_HOME:=$(dirname $0)/..}
 : ${EBASH:=${EBASH_HOME}/share}
 source ${EBASH}/ebash.sh || { echo "Unable to source ${EBASH}/ebash.sh" ; exit 1 ; }
@@ -69,7 +68,6 @@ source ${EBASH}/ebash.sh || { echo "Unable to source ${EBASH}/ebash.sh" ; exit 1
 # both mac and linux
 EBASH=$(readlink -f "${EBASH}")
 EBASH_HOME=$(readlink -f "${EBASH_HOME}")
-
 
 declare name=${0##*/}
 
@@ -140,7 +138,7 @@ else
         # So, a much simpler, and more correct solution is to simply SOURCE the external script (along with arguments).
         # This has the same effect as executing a script only it is run within our existing process context rather than
         # as an external script.
-        if file "${1}" 2>/dev/null | grep -Pq "(bash script|Bourne-Again shell script)"; then
+        if file "${1}" 2>/dev/null | grep -Pq "(ASCII text|bash script|Bourne-Again shell script)"; then
             source "${@}"
             exit $?
         fi

--- a/bin/etest
+++ b/bin/etest
@@ -424,6 +424,9 @@ run_single_test()
     fi
 
     # NOTE: Don't return rc here.  We've already set things up so etest knows if there was a failure.
+    if [[ ${break} -eq 1 && ${#TESTS_FAILED[@]} -gt 0 ]] ; then
+        die "${display_testname} failed and break=1" &>${ETEST_OUT}
+    fi
 }
 
 run_etest_file()

--- a/share/cgroup.sh
+++ b/share/cgroup.sh
@@ -41,11 +41,6 @@ else
     CGROUP_SUBSYSTEMS=(cpu cpuacct memory freezer)
 fi
 
-# We may already be in a cgroup and if so we need to constrain ourselves to only operate within that root cgroup. If we
-# are not in a cgroup at all, this will be just '/'. We filter out user.slice as that's not an actual cgroup we want
-# to stay within.
-CGROUP_ROOT="$(awk -F: '$2 == "'${CGROUP_SUBSYSTEMS[0]}'" {print $3}' /proc/$$/cgroup | sed 's|user.slice||')"
-
 #-------------------------------------------------------------------------------------------------------------------------
 # Detect whether the machine currently running this code is built with kernel support for all of the cgroups subsystems
 # that ebash depends on.
@@ -86,6 +81,10 @@ cgroup_supported()
 
 [[ ${__EBASH_OS} == Linux ]] || return 0
 
+# We may already be in a cgroup and if so we need to constrain ourselves to only operate within that root cgroup. If we
+# are not in a cgroup at all, this will be just '/'. We filter out user.slice as that's not an actual cgroup we want
+# to stay within.
+CGROUP_ROOT="$(awk -F: '$2 == "'${CGROUP_SUBSYSTEMS[0]}'" {print $3}' /proc/$$/cgroup | sed 's|user.slice||')"
 
 #-------------------------------------------------------------------------------------------------------------------------
 # Prior to using a cgroup, you must create it.  It is safe to attempt to

--- a/share/ebash.sh
+++ b/share/ebash.sh
@@ -15,7 +15,21 @@
 # Or to ensure ${EBASH}/bin is in your path and to load it like this:
 #    $(ebash --source)
 #
+# Or just ensure ebash is in your PATH and then modify your shebang interpreter at the top of your script to:
+#    #!/usr/bin/env ebash
+#
 ########################################################################################################################
+
+# In some rare circumstances we may be running under a non-bash shell need to switch over to bash before we can proceed.
+#
+# This can happen if we are invoked through some other interpeter such as via `sh bin/ebash` or `bash bin/ebash.sh`
+# rather than directly calling `bin/ebash`.  When invoked that way, ebash becaomes a parameter of `sh` and bash never
+# gets invoked. This prevents ebash from being setup and executing properly. We solve this by simply checking if we're
+# running inside a native BASH context and if we are not, we simply execute bash directly with our script as a parameter
+# as well as any arguments we were passed.
+if [[ "$(ps -p $$ -ocomm=)" != "bash" ]]; then
+    exec bash "$0" "${@}"
+fi
 
 __EBASH_OS=$(uname)
 

--- a/share/efuncs.sh
+++ b/share/efuncs.sh
@@ -15,6 +15,7 @@ set \
     -o functrace \
     -o nounset   \
     -o pipefail  \
+    +o posix     \
 
 shopt -s           \
     checkwinsize   \

--- a/unittest/ebash_bin_sh
+++ b/unittest/ebash_bin_sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Copyright 2020, Marshall McMullen <marshall.mcmullen@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify it under the terms of the Apache License
+# as published by the Apache Software Foundation, either version 2 of the License, or (at your option) any later
+# version.
+
+$(${EBASH_HOME}/bin/ebash --source)
+
+#-------------------------------------------------------------------------------------------------------------------------
+#
+# Check if we call an ebash-enabled script through /bin/sh (which enables posix mode) doesn't cause errors.
+#
+# NOTE: This is intentionally NOT an etest.  This script must be run in its
+# own TOP-LEVEL shell.
+#-------------------------------------------------------------------------------------------------------------------------
+
+# Create a script to run
+OUTPUT=$(mktemp --tmpdir etest-output-txt-XXXXXX)
+SCRIPT=$(mktemp --tmpdir etest-script-sh-XXXXXX)
+trap_add "rm --force ${OUTPUT} ${SCRIPT}"
+
+cat <<EOF >${SCRIPT}
+#!/bin/bash
+
+$(${EBASH_HOME}/bin/ebash --source)
+
+set -e
+
+einfo "Testing ebash from posix shell"
+echo "HELLO WORLD" > "${OUTPUT}"
+
+EOF
+chmod +x ${SCRIPT}
+
+# Run the script we created above using `sh` interpreter which forces it into POSIX mode.
+if os_distro debian ubuntu; then
+    sh -c "${SCRIPT}"
+else
+    sh "${SCRIPT}"
+fi
+
+# Assert proper order of events happened
+einfo "Output file:"
+cat ${OUTPUT}
+assert_eq 1 $(wc -l ${OUTPUT})
+first=$(head -1 ${OUTPUT})
+
+assert_eq "HELLO WORLD" "${first}"
+
+# exit 0

--- a/unittest/ebash_interpreter
+++ b/unittest/ebash_interpreter
@@ -1,0 +1,15 @@
+#!/usr/bin/env ../../bin/ebash
+#
+# Copyright 2020, Marshall McMullen <marshall.mcmullen@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify it under the terms of the Apache License
+# as published by the Apache Software Foundation, either version 2 of the License, or (at your option) any later
+# version.
+
+set -eu
+
+# If ebash was able to be sourced, this should pass.  If not, einfo won't be a recognized command and the set -eu
+# above will ensure that it fails
+einfo hi
+
+assert_match "$(type einfo)" "einfo is a function"


### PR DESCRIPTION
@ericpe  pointed out that if you call a bash script via `sh` that it is put into POSIX mode. That's the issue! POSIX mode basically disables all the things ebash needs. I added a unit test before I fixed this and indeed was able to easily reproduce this. Basically just added a `set +o posix` to turn posix mode off. Unit test passes now.