### PR TITLE
Ebash color mode

### DIFF
--- a/bin/bashlint
+++ b/bin/bashlint
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2011-2018, Marshall McMullen <marshall.mcmullen@gmail.com> 
+# Copyright 2011-2018, Marshall McMullen <marshall.mcmullen@gmail.com>
 # Copyright 2011-2018, SolidFire, Inc. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify it under the terms of the Apache License
@@ -39,11 +39,11 @@ fail()
 # Also checks some stylistic issues for consistent coding.
 ebanner "Validating bash scripts" PATHS
 for fname in $(grep -lr '^#!/.*bash' ${PATHS[@]} | grep -v '.hg'); do
- 
+
     # If this isn't a bash script skip it
     file ${fname} | grep -Pq "(bash script|Bourne-Again shell script)" || continue
 
-    # Never do any further parsing on our own file since they would all 
+    # Never do any further parsing on our own file since they would all
     # be false positives
     [[ "$(readlink -f ${fname})" == "$(readlink -f $0)" ]] && continue
 
@@ -59,7 +59,7 @@ for fname in $(grep -lr '^#!/.*bash' ${PATHS[@]} | grep -v '.hg'); do
         | grep -vP '#\s*BASHLINT_IGNORE' \
         | grep -vP '^\s*function \w+'    \
         | grep -vP '^\s*\w+\s*\(\)\s*$')
-    
+
     # Initial error state
     RC=0
 
@@ -70,7 +70,7 @@ for fname in $(grep -lr '^#!/.*bash' ${PATHS[@]} | grep -v '.hg'); do
     # Ensure not using removed $(esource ...)
     echo "${CONTENTS}" | egrep '\s*\$\(esource ' \
         && fail "Using removed esource function"
-    
+
     # Ensure not using removed argument parsing functions
     echo "${CONTENTS}" | egrep '(declare_globals|declare_exports|declare_args|declare_opts)' \
         && fail "Using removed declare_globals|declare_exports functions"
@@ -91,7 +91,7 @@ for fname in $(grep -lr '^#!/.*bash' ${PATHS[@]} | grep -v '.hg'); do
     echo "${CONTENTS}" | grep -P '(assert|assert_true|assert_false)\s+\[\[' \
         && fail "Assert commands cannot be followed by a double bracket expression"
 
-    echo "${CONTENTS}" | egrep '(local|export|declare|readonly).*=.*\$\(' \
+    echo "${CONTENTS}" | egrep '(local|export|declare|readonly)\s+.*=.*\$\(' \
         && fail "Combined local variable declaration and assignment masks fatal errors"
 
     [[ ${RC} -eq 0 ]] && eend 0 || { FAILURES+=(${fname}); eend 1; }

--- a/bin/ebash
+++ b/bin/ebash
@@ -91,9 +91,10 @@ if [[ ${name} == "ebash" ]] ; then
     fi
 
     # Setup ebash environment variables
-    export EFUNCS_COLOR="${color}"
-    export EMSG_PREFIX=$(string_trim "${EMSG_PREFIX} ${msg_prefix}")
-    export EINTERACTIVE="${interactive}"
+    export EFUNCS_COLOR EMSG_PREFIX EINTERACTIVE
+    EFUNCS_COLOR="${color}"
+    EMSG_PREFIX=$(string_trim "${EMSG_PREFIX} ${msg_prefix}")
+    EINTERACTIVE="${interactive}"
 
     if [[ ${source} -eq 1 ]] ; then
         export_string="$(declare -p EBASH EBASH_HOME EFUNCS_COLOR EMSG_PREFIX EINTERACTIVE | sed -e 's|declare -x ||' | tr '\n' ' ')"

--- a/bin/ebash
+++ b/bin/ebash
@@ -81,14 +81,26 @@ if [[ ${name} == "ebash" ]] ; then
         "+print_environment printenv p | Dump environment variables that ebash would like to use in a format bash
                             can interpret" \
         ":name n=${0##*/} | Name to use as a starting point for finding functions.  I.e pretend ebash is running
-                            with the specified name.")
+                            with the specified name." \
+        "+color c         | Force explicit color mode." \
+        "+time t          | Prefix every emsg with time." \
+        "+interactive i   | Force interactive mode even if we are not attached to a terminal.")
 
     if [[ -n ${load} ]] ; then
         source "${load}"
     fi
 
+    # Setup ebash environment variables if requested
+    : ${EFUNCS_COLOR:=}
+    : ${EMSG_PREFIX:=}
+    : ${EINTERACTIVE:=}
+    [[ ${color} -eq 1 ]] && EFUNCS_COLOR=1
+    [[ ${time}  -eq 1 ]] && EMSG_PREFIX="time_rfc3339 ${EMSG_PREFIX}"
+    [[ ${interactive} -eq 1 ]] && EINTERACTIVE=1
+
     if [[ ${source} -eq 1 ]] ; then
-        echo "eval export EBASH=${EBASH} EBASH_HOME=${EBASH_HOME} ; source \"${EBASH}/ebash.sh\" || { echo \"Unable to source ${EBASH}/ebash.sh\" ; exit 1 ; }"
+        export_string="$(declare -p EBASH EBASH_HOME EFUNCS_COLOR EMSG_PREFIX EINTERACTIVE | sed -e 's|declare -.* ||' | tr '\n' ' ')"
+        echo "eval export ${export_string}; source \"${EBASH}/ebash.sh\" || { echo \"Unable to source ${EBASH}/ebash.sh\" ; exit 1 ; }"
         exit 0
     elif [[ ${print_environment} -eq 1 ]] ; then
         printf "export EBASH=%q\n" "${EBASH}"

--- a/bin/ebash
+++ b/bin/ebash
@@ -75,31 +75,28 @@ declare name=${0##*/}
 if [[ ${name} == "ebash" ]] ; then
 
     $(opt_parse \
-        ":load l          | ebash should source the specified file before attempting to run the specified command." \
-        "+source s        | Print commands that would load ebash from its existing location on disk into the current
-                            shell and then exit.  You'd use this in a script like this: \$(ebash --source)" \
-        "+print_environment printenv p | Dump environment variables that ebash would like to use in a format bash
-                            can interpret" \
-        ":name n=${0##*/} | Name to use as a starting point for finding functions.  I.e pretend ebash is running
-                            with the specified name." \
-        "+color c         | Force explicit color mode." \
-        "+time t          | Prefix every emsg with time." \
-        "+interactive i   | Force interactive mode even if we are not attached to a terminal.")
+        ":load l                                | ebash should source the specified file before attempting to run the specified command." \
+        "+source s                              | Print commands that would load ebash from its existing location on disk into the current
+                                                  shell and then exit.  You'd use this in a script like this: \$(ebash --source)" \
+        "+print_environment printenv p          | Dump environment variables that ebash would like to use in a format bash
+                                                  can interpret" \
+        ":name n=${0##*/}                       | Name to use as a starting point for finding functions.  I.e pretend ebash is running
+                                                  with the specified name." \
+        "+color c=$(efuncs_color_as_bool)       | Force explicit color mode." \
+        ":msg_prefix m                          | Prefix to use for all emsg messages." \
+        "+interactive i=$(einteractive_as_bool) | Force interactive mode even if we are not attached to a terminal.")
 
     if [[ -n ${load} ]] ; then
         source "${load}"
     fi
 
-    # Setup ebash environment variables if requested
-    : ${EFUNCS_COLOR:=}
-    : ${EMSG_PREFIX:=}
-    : ${EINTERACTIVE:=}
-    [[ ${color} -eq 1 ]] && EFUNCS_COLOR=1
-    [[ ${time}  -eq 1 ]] && EMSG_PREFIX="time_rfc3339 ${EMSG_PREFIX}"
-    [[ ${interactive} -eq 1 ]] && EINTERACTIVE=1
+    # Setup ebash environment variables
+    export EFUNCS_COLOR="${color}"
+    export EMSG_PREFIX=$(string_trim "${EMSG_PREFIX} ${msg_prefix}")
+    export EINTERACTIVE="${interactive}"
 
     if [[ ${source} -eq 1 ]] ; then
-        export_string="$(declare -p EBASH EBASH_HOME EFUNCS_COLOR EMSG_PREFIX EINTERACTIVE | sed -e 's|declare -.* ||' | tr '\n' ' ')"
+        export_string="$(declare -p EBASH EBASH_HOME EFUNCS_COLOR EMSG_PREFIX EINTERACTIVE | sed -e 's|declare -x ||' | tr '\n' ' ')"
         echo "eval export ${export_string}; source \"${EBASH}/ebash.sh\" || { echo \"Unable to source ${EBASH}/ebash.sh\" ; exit 1 ; }"
         exit 0
     elif [[ ${print_environment} -eq 1 ]] ; then

--- a/bin/elint
+++ b/bin/elint
@@ -1,0 +1,1 @@
+bashlint

--- a/share/emsg.sh
+++ b/share/emsg.sh
@@ -23,6 +23,9 @@
 # By default enable eprogress style tickers
 : ${EPROGRESS:=1}
 
+# Default timestamp format to use
+: ${ETIMESTAMP_FORMAT:=rfc3339}
+
 # Any functions whose names are "==" to this are exempt from ETRACE.  In other
 # words, even if ETRACE=1, these functions actions will not be displayed in the
 # output.
@@ -150,6 +153,16 @@ einteractive()
     [[ -t 2 ]]
 }
 
+# Get einteractive value as a boolean string
+einteractive_as_bool()
+{
+    if einteractive; then
+        echo -n "1"
+    else
+        echo -n "0"
+    fi
+}
+
 ecolor_code()
 {
    case $1 in
@@ -237,6 +250,29 @@ ecolor_code()
    return 0
 }
 
+# Determine value to use for efuncs_color.
+# If EFUNCS_COLOR is empty then set it based on if STDERR is attached to a console
+efuncs_color()
+{
+    ## If EFUNCS_COLOR is empty then set it based on if STDERR is attached to a console
+    local value=${EFUNCS_COLOR:=}
+    if [[ -z ${value} ]] && einteractive ; then
+        value=1
+    fi
+
+    [[ ${value} -eq 1 ]]
+}
+
+# Get efuncs_color as a boolean string.
+efuncs_color_as_bool()
+{
+    if efuncs_color; then
+        echo "1"
+    else
+        echo "0"
+    fi
+}
+
 ecolor()
 {
     ## If EFUNCS_COLOR is empty then set it based on if STDERR is attached to a console
@@ -302,7 +338,13 @@ eclear()
 
 etimestamp()
 {
-    echo -en "$(date '+%b %d %T.%3N')"
+    if [[ "${ETIMESTAMP_FORMAT:-}" == "simple" ]]; then
+        echo -en "$(date '+%b %d %T.%3N')"
+    elif [[ "${ETIMESTAMP_FORMAT:-}" == "rfc3339" ]]; then
+        echo -en "$(date '+%FT%TZ')"
+    else
+        die "Unsupported $(lval ETIMESTAMP_FORMAT)"
+    fi
 }
 
 etimestamp_rfc3339()

--- a/share/emsg.sh
+++ b/share/emsg.sh
@@ -23,8 +23,10 @@
 # By default enable eprogress style tickers
 : ${EPROGRESS:=1}
 
-# Default timestamp format to use
-: ${ETIMESTAMP_FORMAT:=rfc3339}
+# Default timestamp format to use. Supports:
+# RFC3339       (e.g. "2006-01-02T15:04:05Z07:00")
+# StampMilli    (e.g. "Jan _2 15:04:05.000")
+: ${ETIMESTAMP_FORMAT:=RFC3339}
 
 # Any functions whose names are "==" to this are exempt from ETRACE.  In other
 # words, even if ETRACE=1, these functions actions will not be displayed in the
@@ -338,9 +340,9 @@ eclear()
 
 etimestamp()
 {
-    if [[ "${ETIMESTAMP_FORMAT:-}" == "simple" ]]; then
+    if [[ "${ETIMESTAMP_FORMAT:-}" == "StampMilli" ]]; then
         echo -en "$(date '+%b %d %T.%3N')"
-    elif [[ "${ETIMESTAMP_FORMAT:-}" == "rfc3339" ]]; then
+    elif [[ "${ETIMESTAMP_FORMAT:-}" == "RFC3339" ]]; then
         echo -en "$(date '+%FT%TZ')"
     else
         die "Unsupported $(lval ETIMESTAMP_FORMAT)"
@@ -349,7 +351,7 @@ etimestamp()
 
 etimestamp_rfc3339()
 {
-    echo -en "$(date '+%FT%TZ')"
+    echo -en $(date '+%FT%TZ')
 }
 
 opt_usage ebanner<<'END'

--- a/unittest/ebash.etest
+++ b/unittest/ebash.etest
@@ -130,21 +130,23 @@ ETEST_ebash_bin_printenv()
 ETEST_ebash_color()
 {
     ${EBASH_HOME}/bin/ebash --source --color    | grep 'EFUNCS_COLOR="1"'
-    #${EBASH_HOME}/bin/ebash --source --no-color | grep 'EFUNCS_COLOR="0"'
+    ${EBASH_HOME}/bin/ebash --source --no-color | grep 'EFUNCS_COLOR="0"'
 
     EFUNCS_COLOR=0 ${EBASH_HOME}/bin/ebash --source --color | grep 'EFUNCS_COLOR="1"'
 }
 
-ETEST_ebash_time()
-{
-    ${EBASH_HOME}/bin/ebash --source --time | grep 'EMSG_PREFIX="time_rfc3339"'
-    #${EBASH_HOME}/bin/ebash --source --no-time | grep 'EMSG_PREFIX=""'
-
-    EMSG_PREFIX=level ${EBASH_HOME}/bin/ebash --source --time | grep 'EMSG_PREFIX="level time_rfc3339"'
-}
-
 ETEST_ebash_interactive()
 {
-    ${EBASH_HOME}/bin/ebash --source --interactive | grep 'EINTERACTIVE="1"'
-    #${EBASH_HOME}/bin/ebash --source --no-interactive | grep 'EINTERACTIVE=""'
+    ${EBASH_HOME}/bin/ebash --source --interactive    | grep 'EINTERACTIVE="1"'
+    ${EBASH_HOME}/bin/ebash --source --no-interactive | grep 'EINTERACTIVE="0"'
+}
+
+ETEST_ebash_msg_prefix()
+{
+    ${EBASH_HOME}/bin/ebash --source --msg-prefix=time
+    ${EBASH_HOME}/bin/ebash --source --msg-prefix=time | grep 'EMSG_PREFIX="time"'
+    ${EBASH_HOME}/bin/ebash --source --msg-prefix="all" | grep 'EMSG_PREFIX="all"'
+    ${EBASH_HOME}/bin/ebash --source --msg-prefix=""    | grep 'EMSG_PREFIX=""'
+
+    EMSG_PREFIX=level ${EBASH_HOME}/bin/ebash --source --msg-prefix=time | grep 'EMSG_PREFIX="level time"'
 }

--- a/unittest/ebash.etest
+++ b/unittest/ebash.etest
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2011-2018, Marshall McMullen <marshall.mcmullen@gmail.com> 
+# Copyright 2011-2018, Marshall McMullen <marshall.mcmullen@gmail.com>
 # Copyright 2011-2018, SolidFire, Inc. All rights reserved.
 #
 # Tests specifically for the ebash binary
@@ -36,7 +36,7 @@ ETEST_ebash_bin_symlink_name_plus_func()
     assert_eq "omega  alpha" "${stdout}"
 }
 
-ETEST_ebash_bin_calls_ibu()
+ETEST_ebash_bin_calls_repl()
 {
     $(tryrc --rc rc --stderr stderr ${EBASH_HOME}/bin/ebash</dev/null)
 
@@ -69,7 +69,7 @@ ETEST_ebash_bin_specify_name()
 }
 
 ETEST_ebash_bin_right_args()
-{ 
+{
 cat<<'EOF' >testfile.sh
 argchecker()
 {
@@ -125,4 +125,26 @@ ETEST_ebash_bin_printenv()
         assert_eq "${ACTUAL_EBASH_HOME}" "${EBASH_HOME}"
         assert_eq "${ACTUAL_EBASH}" "${EBASH}"
     )
+}
+
+ETEST_ebash_color()
+{
+    ${EBASH_HOME}/bin/ebash --source --color    | grep 'EFUNCS_COLOR="1"'
+    #${EBASH_HOME}/bin/ebash --source --no-color | grep 'EFUNCS_COLOR="0"'
+
+    EFUNCS_COLOR=0 ${EBASH_HOME}/bin/ebash --source --color | grep 'EFUNCS_COLOR="1"'
+}
+
+ETEST_ebash_time()
+{
+    ${EBASH_HOME}/bin/ebash --source --time | grep 'EMSG_PREFIX="time_rfc3339"'
+    #${EBASH_HOME}/bin/ebash --source --no-time | grep 'EMSG_PREFIX=""'
+
+    EMSG_PREFIX=level ${EBASH_HOME}/bin/ebash --source --time | grep 'EMSG_PREFIX="level time_rfc3339"'
+}
+
+ETEST_ebash_interactive()
+{
+    ${EBASH_HOME}/bin/ebash --source --interactive | grep 'EINTERACTIVE="1"'
+    #${EBASH_HOME}/bin/ebash --source --no-interactive | grep 'EINTERACTIVE=""'
 }

--- a/unittest/emsg.etest
+++ b/unittest/emsg.etest
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2011-2018, Marshall McMullen <marshall.mcmullen@gmail.com> 
+# Copyright 2011-2018, Marshall McMullen <marshall.mcmullen@gmail.com>
 # Copyright 2011-2018, SolidFire, Inc. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify it under the terms of the Apache License
@@ -10,7 +10,7 @@
 show_text()
 {
     [[ ${TEXT:-0} -eq 1 ]] || return 0
-    head /etc/fstab 
+    head /etc/fstab
     return 0
 }
 
@@ -50,6 +50,11 @@ ETEST_emsg_time_rfc3339()
 ETEST_emsg_time_legacy()
 {
     EFUNCS_TIME=1 emsg_aux
+}
+
+ETEST_emsg_time_simple()
+{
+    ETIMESTAMP_FORMAT=simple emsg_aux
 }
 
 ETEST_emsg_level()
@@ -128,7 +133,7 @@ ETEST_ecolor_chart()
     pad=$(printf '%0.1s' " "{1..60})
     padlength=20
     line=0
-    
+
     for c in ${ETEST_COLORS[@]}; do
         printf "%s%*.*s" "$(ecolor $c)${c}$(ecolor none)" 0 $((padlength - ${#c} )) "${pad}"
         (( ++line % 8 == 0 )) && printf "\n" || true
@@ -136,7 +141,7 @@ ETEST_ecolor_chart()
         c="dim ${c}"
         printf "%s%*.*s" "$(ecolor $c)${c}$(ecolor none)" 0 $((padlength - ${#c} )) "${pad}"
         (( ++line % 8 == 0 )) && printf "\n" || true
- 
+
     done
 
     echo ""
@@ -260,7 +265,7 @@ ETEST_noansi_files()
     declare a_contents b_contents
     a_contents="$(cat file_a)"
     b_contents="$(cat file_b)"
-    
+
     assert_ne "A" "${a_contents}"
     assert_ne "B" "${b_contents}"
 
@@ -377,7 +382,7 @@ ETEST_eprogress_ticker_align_invalid()
     $(tryrc eprogress --align RIGHT)
     assert_eq 1 "${rc}"
 }
- 
+
 ETEST_eprogress_ticker_align_right()
 {
     etestmsg "Starting background process that writes to ${OUTPUT}"

--- a/unittest/emsg.etest
+++ b/unittest/emsg.etest
@@ -47,6 +47,35 @@ ETEST_emsg_time_rfc3339()
     EMSG_PREFIX="time_rfc3339" emsg_aux
 }
 
+# Function to normalize seconds and milliseconds to avoid slight time delta false positive
+normalize_time_stamp()
+{
+    sed 's|[0-9].[0-9][0-9][0-9]|0.000|'
+}
+
+# Function to normalize rfc3339 time to avoid slight time delta false positive
+normalize_time_rfc3339()
+{
+    sed 's|[0-9]:[0-9][0-9]Z|0:00Z|'
+}
+
+ETEST_etimestamp_format()
+{
+    (
+        ETIMESTAMP_FORMAT="StampMilli"
+        expect="$(date '+%b %d %T.%3N' | normalize_time_stamp)"
+        actual="$(etimestamp | normalize_time_stamp)"
+        einfo "$(lval ETIMESTAMP_FORMAT expect actual)"
+        assert_eq "${expect}" "${actual}"
+
+        ETIMESTAMP_FORMAT="RFC3339"
+        expect="$(date '+%FT%TZ' | normalize_time_rfc3339)"
+        actual="$(etimestamp | normalize_time_rfc3339)"
+        einfo "$(lval ETIMESTAMP_FORMAT expect actual)"
+        assert_eq "${expect}" "${actual}"
+    )
+}
+
 ETEST_emsg_time_legacy()
 {
     EFUNCS_TIME=1 emsg_aux


### PR DESCRIPTION
This fixes #26 by adding new option flags to ebash to make it less onerous to setup some default settings. I like option flags better than env variables as they are more transparent what we're doing, show up in usage statements and logs, etc. env variables are just to opaque.

This adds 

```
--color
--interactive
--msg-prefix
```

Now you can say
```
$(/liqid/ebash/bin/ebash --source --color --interactive --msg-prefix=time)
```

I also changed `etimestamp` to use `RFC3339` by default everywhere. The only way to get the old behavior is to set new `ETIMESTAMP_FORMAT=StampMilli` vs the new default `RFC3339`. But honestly, `RFC3339` is really what we should be using everywhere by now.