### PR TITLE
Opt nonempty string

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,9 @@ good explanation as to why bash wouldn’t invoke its error trap if there is one
 
 As long as you handle your cleanup in an `EXIT` trap, which is what `trap_add` does by default, it’ll be fine.
 
-## Common Logging and Output Styles ### A standard, styleable output format
+## Common Logging and Output Styles
+
+### A standard, styleable output format
 
 ebash provides a few standard functions intended for logging output to the screen.  `Einfo` is intended for standard
 flow information in the typical case.  `Ewarn` indicate non-fatal things that might warrant user attention.  `Eerror`
@@ -386,7 +388,9 @@ immensely helpful when you really need it.
 One caveat: you can’t change the value of `ETRACE` on the fly.  The value it had when you sourced ebash is the one that
 will affect the entire runtime of the script.
 
-## Data Structures ### Array Helpers
+## Data Structures
+
+### Array Helpers
 
 In `array.sh`, there are several helpers for dealing with standard bash arrays.  These are helpers for dealing with
 standard bash arrays.  The best place to get information on these right now is in the documentation headers above each
@@ -505,7 +509,7 @@ And the ability to give arguments default values.
         "arg1=a | Argument that defaults to a" \
         "arg2=b | Argument that defaults to b)
 
-`Opt_parse` can even deal with short and gnu-style long options.  There's much more information in its documentation,
+`opt_parse` can even deal with short and gnu-style long options.  There's much more information in its documentation,
 but here's an example to whet your appetite:
 
     $(opt_parse \
@@ -514,6 +518,100 @@ but here's an example to whet your appetite:
         "+bool b        | Boolean option (value of 1 or 0)" \
         "arg            | Positional argument")
 
+#### Boolean Options
+
+`opt_parse` supports boolean options. That is, they're either on the command line (in which case opt_parse assigns 1 to
+the variable) or not on the command line (in which case opt_parse assigns 0 to the variable).
+
+You can also be explicit about the value you'd like to choose for an option by specifying =0 or =1 at the end of the
+option. For instance, these are equivalent and would enable the word_regex option and disable the invert option.
+
+    cmd --invert=0 --word-regex=1
+    cmd -i=0 -w=1
+
+Note that these two options are considered to be boolean. Either they were specified on the command line or they were
+not. When specified, the value of the variable will be 1, when not specified it will be zero.
+
+The long option versions of boolean options also implicitly support a negation by prepending the option name with no-.
+For example, this is also equivalent to the above examples.
+
+    cmd --no-invert --word-regex
+
+#### String Options
+
+`opt_parse` also supports options whose value is a string. When specified on the command line, these _require_ an
+argument, even if it is an empty string. In order to get a string option, you prepend its name with a colon character.
+
+    func()
+    {
+        $(opt_parse ":string s")
+        echo "STRING="${string}""
+    }
+
+    func --string "alpha"
+    # output: STRING="alpha"
+    func --string ""
+    # output: STRING=""
+
+    func --string=alpha
+    # output: STRING="alpha"
+    func --string=
+    # output: STRING=""
+
+#### Non-Empty String Options
+
+`opt_parse` also supports options whose value is a non-empty string. This is identical to a normal `:` string option
+only it is more strict since the string argument must be non-empty. In order to use this option, prepend its name with
+an equal character.
+
+    func()
+    {
+        $(opt_parse "=string s")
+        echo "STRING="${string}""
+    }
+
+    func --string "alpha"
+    # output: STRING="alpha"
+    func --string ""
+    # error: option --string requires a non-empty argument.
+
+    func --string=alpha
+    # output: STRING="alpha"
+    func --string=
+    # error: option --string requires a non-empty argument.
+
+#### Accumulator Values
+
+`opt_parse` also supports the ability to accumulate string values into an array when the option is given multiple times.
+In order to use an accumulator, you prepend its name with an ampersand character. The values placed into an accumulated
+array cannot contain a newline character.
+
+    func()
+    {
+        $(opt_parse "&files f")
+        echo "FILES: ${files[@]}"
+    }
+
+    func --files "alpha" --files "beta" --files "gamma"
+    # output -- FILES: alpha beta gamma
+
+#### Default Values
+
+By default, the value of boolean options is false and string options are an empty string, but you can specify a default
+in your definition just as you would with arguments.
+
+    $(opt_parse \
+        "+boolean b=1        | Boolean option that defaults to true" \
+        ":string s=something | String option that defaults to "something")
+
+
+#### Automatic --help / -?
+
+`opt_parse` automatically supports --help option and corresponding short option -? option for you, which will display a
+usage statement using the docstrings that you provided for each of the options and arguments.
+
+Functions called with --help/-? as processed by opt_parse will not perform their typical operation and will instead
+return successfully after printing this usage statement.
 
 ### Clean up after yourself
 

--- a/bin/ebash
+++ b/bin/ebash
@@ -83,7 +83,7 @@ if [[ ${name} == "ebash" ]] ; then
         "=name n=${0##*/}                       | Name to use as a starting point for finding functions.  I.e pretend ebash is running
                                                   with the specified name." \
         "+color c=$(efuncs_color_as_bool)       | Force explicit color mode." \
-        "=msg_prefix m                          | Prefix to use for all emsg messages." \
+        ":msg_prefix m                          | Prefix to use for all emsg messages." \
         "+interactive i=$(einteractive_as_bool) | Force interactive mode even if we are not attached to a terminal.")
 
     if [[ -n ${load} ]] ; then

--- a/bin/ebash
+++ b/bin/ebash
@@ -8,52 +8,43 @@
 # version.
 
 #
-# This tool is designed to run individual commands in a ebash environment.
-# It can effectively turns ebash functions into commands that can easily be
-# run from a shell prompt.
+# This tool is designed to run individual commands in a ebash environment. It can effectively turns ebash functions
+# into commands that can easily be run from a shell prompt.
 #
-# The first simple use case happens when the binary is called "ebash".  In
-# this mode, everything after ebash on the command line is evaluated inside
-# a bash interpreter that has sourced the various ebash source files.
+# The first simple use case happens when the binary is called "ebash". In this mode, everything after ebash on the
+# command line is evaluated inside a bash interpreter that has sourced the various ebash source files.
 #
-# But ebash can be symlinked to other names.  ebash pays attention to
-# the name that it is called by.  When it's not called as ebash, it tries
-# to run ebash functions intead.  First, it looks to see if the symlink
-# name is the name of a "namespace" of ebash commands.  For instance, the
-# string commands can be used in this way.  Assuming a "string" symlink, then
+# But ebash can be symlinked to other names. ebash pays attention to the name that it is called by. When it's not
+# called as ebash, it tries to run ebash functions intead. First, it looks to see if the symlink name is the name of a
+# "namespace" of ebash commands. For instance, the string commands can be used in this way. Assuming a "string"
+# symlink, then
 #
 #     string trim " a string to trim "
 #
-# will call the string_trim function, passing it that string as an argument.
-# If there is no function that's a combination of the symlink name and the
-# first argument, then ebash will look for a function of the same name as
-# the symlink and call it passing all arguments to the function.  For instance,
-# given a symlink called eunmount, then you could call
+# will call the string_trim function, passing it that string as an argument. If there is no function that's a
+# combination of the symlink name and the first argument, then ebash will look for a function of the same name as the
+# symlink and call it passing all arguments to the function. For instance, given a symlink called eunmount, then you
+# could call
 #
 #     eunmount /path/to/unmount /another/path
 #
-# And both "/path/to/unmount" and "/another/path" will be passed as arguments
-# to eunmount.
+# And both "/path/to/unmount" and "/another/path" will be passed as arguments to eunmount.
 #
 #-------------------------------------------------------------------------------
 
 
-# To be able to make good use of function documentation in places where we do
-# something like this, we need to save function documentation off into
-# variables (or else we'd have to parse bash source code enough to extract it,
-# which sounds very error prone)
+# To be able to make good use of function documentation in places where we do something like this, we need to save
+# function documentation off into variables (or else we'd have to parse bash source code enough to extract it, which
+# sounds very error prone)
 #
 #     somefunc --help
 #
-# But we don't want to bloat the interpreter with a bunch of documentation
-# every time we source ebash.  Our solution is to only save them at times
-# where we believe the variables are going to be needed.  There's no reason to
-# expect they will be necessary unless `--help` is on the command line
-# somewhere.  Or for those few cases where it's needed, they can set this
-# variable, too.
+# But we don't want to bloat the interpreter with a bunch of documentation every time we source ebash. Our solution is
+# to only save them at times where we believe the variables are going to be needed. There's no reason to expect they
+# will be necessary unless `--help` is on the command line somewhere. Or for those few cases where it's needed, they
+# can set this variable, too.
 #
-# And for this to work in all of the ebash files, we must do it before
-# sourcing them.
+# And for this to work in all of the ebash files, we must do it before sourcing them.
 for arg in "$@" ; do
     if [[ ${arg} == "--help" ]] ; then
         __EBASH_SAVE_DOC=1
@@ -75,13 +66,15 @@ declare name=${0##*/}
 if [[ ${name} == "ebash" ]] ; then
 
     $(opt_parse \
-        "=load l                                | ebash should source the specified file before attempting to run the specified command." \
-        "+source s                              | Print commands that would load ebash from its existing location on disk into the current
-                                                  shell and then exit.  You'd use this in a script like this: \$(ebash --source)" \
-        "+print_environment printenv p          | Dump environment variables that ebash would like to use in a format bash
-                                                  can interpret" \
-        "=name n=${0##*/}                       | Name to use as a starting point for finding functions.  I.e pretend ebash is running
-                                                  with the specified name." \
+        ":load l                                | ebash should source the specified file before attempting to run the
+                                                  specified command." \
+        "+source s                              | Print commands that would load ebash from its existing location on
+                                                  disk into the current shell and then exit. You'd use this in a script
+                                                  like this: \$(ebash --source)" \
+        "+print_environment printenv p          | Dump environment variables that ebash would like to use in a format
+                                                  bash can interpret" \
+        ":name n=${0##*/}                       | Name to use as a starting point for finding functions. This basically
+                                                  pretends that ebash is running with the specified name." \
         "+color c=$(efuncs_color_as_bool)       | Force explicit color mode." \
         ":msg_prefix m                          | Prefix to use for all emsg messages." \
         "+interactive i=$(einteractive_as_bool) | Force interactive mode even if we are not attached to a terminal.")
@@ -138,12 +131,12 @@ else
         # Originally we copied the script we were given into a temporary directory and then modified it to source the
         # ebash environment at the top of the script. That had several undesirable side-effects:
         #
-        # (1) Required file operations just to run a script
-        # (2) Extra overhead of fork/exec to run the external script.
-        # (3) Error prone to be running sed commands on arbitrary script contents
-        # (4) Alters the called script's ${BASH_SOURCE} such that it looked like the script path is /tmp/blahXXXX
-        #     rather than the actual location of the script. This is really bad since the caller may want to have
-        #     access to files relative to it's source directory.
+        # 1) Required file operations just to run a script
+        # 2) Extra overhead of fork/exec to run the external script.
+        # 3) Error prone to be running sed commands on arbitrary script contents
+        # 4) Alters the called script's ${BASH_SOURCE} such that it looked like the script path is /tmp/blahXXXX rather
+        #    than the actual location of the script. This is really bad since the caller may want to have access to
+        #    files relative to it's source directory.
         #
         # So, a much simpler, and more correct solution is to simply SOURCE the external script (along with arguments).
         # This has the same effect as executing a script only it is run within our existing process context rather than

--- a/bin/ebash
+++ b/bin/ebash
@@ -75,15 +75,15 @@ declare name=${0##*/}
 if [[ ${name} == "ebash" ]] ; then
 
     $(opt_parse \
-        ":load l                                | ebash should source the specified file before attempting to run the specified command." \
+        "=load l                                | ebash should source the specified file before attempting to run the specified command." \
         "+source s                              | Print commands that would load ebash from its existing location on disk into the current
                                                   shell and then exit.  You'd use this in a script like this: \$(ebash --source)" \
         "+print_environment printenv p          | Dump environment variables that ebash would like to use in a format bash
                                                   can interpret" \
-        ":name n=${0##*/}                       | Name to use as a starting point for finding functions.  I.e pretend ebash is running
+        "=name n=${0##*/}                       | Name to use as a starting point for finding functions.  I.e pretend ebash is running
                                                   with the specified name." \
         "+color c=$(efuncs_color_as_bool)       | Force explicit color mode." \
-        ":msg_prefix m                          | Prefix to use for all emsg messages." \
+        "=msg_prefix m                          | Prefix to use for all emsg messages." \
         "+interactive i=$(einteractive_as_bool) | Force interactive mode even if we are not attached to a terminal.")
 
     if [[ -n ${load} ]] ; then

--- a/bin/ebash-repl
+++ b/bin/ebash-repl
@@ -80,7 +80,7 @@ die_handler()
 }
 
 $(opt_parse \
-    ":load l | Load the specified file prior to running the interactive interpreter.")
+    "=load l | Load the specified file prior to running the interactive interpreter.")
 
 if [[ -n "${load}" ]] ; then
     source "${load}"

--- a/bin/etest
+++ b/bin/etest
@@ -35,35 +35,35 @@ TOPDIR=${PWD}
 $(opt_parse \
     "+break   b=${BREAK:-0}    | Stop immediately on first failure." \
     "+clean   c=0              | Clean only and then exit." \
-    ":debug   D=${EDEBUG:-}    | EDEBUG output." \
+    "=debug   D=${EDEBUG:-}    | EDEBUG output." \
     "+delete  d=1              | Delete all output files when tests complete." \
-    ":exclude x                | Tests whose name or file match this (bash-style) regular expression will not be run." \
-    ":failures=${FAILURES:-0}  | Number of failures per-test to permit. Normally etest will return non-zero if any
+    "=exclude x                | Tests whose name or file match this (bash-style) regular expression will not be run." \
+    "=failures=${FAILURES:-0}  | Number of failures per-test to permit. Normally etest will return non-zero if any
                                  test fails at all. However, in certain circumstances where flaky tests exist it may
                                  be desireable to allow each test to retried a specified number of times and only
                                  classify it as a failure if that test fails more than the requested threshold." \
-    ":filter  f                | Tests whose name or file match this (bash-style) regular expression will be run." \
+    "=filter  f                | Tests whose name or file match this (bash-style) regular expression will be run." \
     "+html    h=0              | Produce an HTML logfile and strip color codes out of etest.log." \
-    ":log_dir                  | Directory to place logs in.  Defaults to the current directory." \
+    "=log_dir                  | Directory to place logs in. Defaults to the current directory." \
     "+mount_ns=1               | Run tests inside a mount namespace." \
-    ":repeat  r=${REPEAT:-1}   | Number of times to repeat each test." \
+    "=repeat  r=${REPEAT:-1}   | Number of times to repeat each test." \
     "+summary s=0              | Display final summary to terminal in addition to logging it to etest.json." \
-    "&test_list l              | File that contains a list of tests to run.  This file may contain comments on lines
-                                 that begin with the # character.  All other nonblank lines will be interpreted as
+    "&test_list l              | File that contains a list of tests to run. This file may contain comments on lines
+                                 that begin with the # character. All other nonblank lines will be interpreted as
                                  things that could be passed as @tests -- directories, executable scripts, or .etest
-                                 files.  Relative paths will be interpreted against the current directory.  This option
+                                 files. Relative paths will be interpreted against the current directory. This option
                                  may be specified multiple times." \
     "+verbose v=${VERBOSE:-0}  | Verbose output." \
-    ":work_dir                 | Temporary location where etest can place temporary files.  This location will be both
+    "=work_dir                 | Temporary location where etest can place temporary files. This location will be both
                                  created and deleted by etest." \
     "@tests                    | Any number of individual tests, which may be executables to be executed and checked for
                                  exit code or may be files whose names end in .etest, in which case they will be sourced
-                                 and any test functions found will be executed.  You may also specify directories in
+                                 and any test functions found will be executed. You may also specify directories in
                                  which case etest will recursively find executables and .etest files and treat them in
                                  similar fashion.")
 
-# Default settings for filter an exclude.  Note that we can't use the opt_parse "default value" feature for this,
-# because our values are regular expressions.  That is, they're fairly likely to contain pipe characters and that would
+# Default settings for filter an exclude. Note that we can't use the opt_parse "default value" feature for this,
+# because our values are regular expressions. That is, they're fairly likely to contain pipe characters and that would
 # cause opt_parse to do crazy things.
 : ${filter:=${FILTER:-}}
 : ${exclude:=${EXCLUDE:-}}
@@ -198,7 +198,7 @@ assert_no_process_leaks()
 
     edebug "Waiting..."
 
-    # Wait for up to 5 seconds for leaked processes to die off.  If anything
+    # Wait for up to 5 seconds for leaked processes to die off. If anything
     # lasts beyond that, we'll call it a test failure.
     $(tryrc eretry -T=5s no_process_leaks_remain)
 
@@ -290,7 +290,7 @@ run_single_test()
         ":testidx       | Test index of current test. Mose useful if the test is a function inside a test suite." \
         ":testidx_total | Total number of tests. Most useful if the test is a function inside a test suite." \
         ":work_dir      | Temporary directory that the test should use as its current working directory." \
-        ":source        | Name file to be sourced in the shell that will run the test.  Most useful if the test is a function
+        ":source        | Name file to be sourced in the shell that will run the test. Most useful if the test is a function
                           inside that file." \
         "testname       | Command to execute to run the test")
 
@@ -332,7 +332,7 @@ run_single_test()
         # We want to make sure that any traps from the tests
         # execute _before_ we run teardown, and also we don't
         # want the teardown to run inside the test-specific
-        # cgroup.  This subshell solves both issues.
+        # cgroup. This subshell solves both issues.
         try
         {
             export EBASH EBASH_HOME TEST_DIR_OUTPUT=${work_dir}
@@ -442,7 +442,7 @@ run_single_test()
         $(tryrc -r=teardown_rc teardown)
     fi
 
-    # NOTE: Don't return rc here.  We've already set things up so etest knows if there was a failure.
+    # NOTE: Don't return rc here. We've already set things up so etest knows if there was a failure.
     if [[ ${break} -eq 1 && ${#TESTS_FAILED[@]} -gt 0 ]] ; then
         die "${display_testname} failed and break=1" &>${ETEST_OUT}
     fi

--- a/bin/etest
+++ b/bin/etest
@@ -35,18 +35,18 @@ TOPDIR=${PWD}
 $(opt_parse \
     "+break   b=${BREAK:-0}    | Stop immediately on first failure." \
     "+clean   c=0              | Clean only and then exit." \
-    "=debug   D=${EDEBUG:-}    | EDEBUG output." \
+    ":debug   D=${EDEBUG:-}    | EDEBUG output." \
     "+delete  d=1              | Delete all output files when tests complete." \
-    "=exclude x                | Tests whose name or file match this (bash-style) regular expression will not be run." \
-    "=failures=${FAILURES:-0}  | Number of failures per-test to permit. Normally etest will return non-zero if any
+    ":exclude x                | Tests whose name or file match this (bash-style) regular expression will not be run." \
+    ":failures=${FAILURES:-0}  | Number of failures per-test to permit. Normally etest will return non-zero if any
                                  test fails at all. However, in certain circumstances where flaky tests exist it may
                                  be desireable to allow each test to retried a specified number of times and only
                                  classify it as a failure if that test fails more than the requested threshold." \
-    "=filter  f                | Tests whose name or file match this (bash-style) regular expression will be run." \
+    ":filter  f                | Tests whose name or file match this (bash-style) regular expression will be run." \
     "+html    h=0              | Produce an HTML logfile and strip color codes out of etest.log." \
-    "=log_dir                  | Directory to place logs in. Defaults to the current directory." \
+    ":log_dir                  | Directory to place logs in. Defaults to the current directory." \
     "+mount_ns=1               | Run tests inside a mount namespace." \
-    "=repeat  r=${REPEAT:-1}   | Number of times to repeat each test." \
+    ":repeat  r=${REPEAT:-1}   | Number of times to repeat each test." \
     "+summary s=0              | Display final summary to terminal in addition to logging it to etest.json." \
     "&test_list l              | File that contains a list of tests to run. This file may contain comments on lines
                                  that begin with the # character. All other nonblank lines will be interpreted as
@@ -54,7 +54,7 @@ $(opt_parse \
                                  files. Relative paths will be interpreted against the current directory. This option
                                  may be specified multiple times." \
     "+verbose v=${VERBOSE:-0}  | Verbose output." \
-    "=work_dir                 | Temporary location where etest can place temporary files. This location will be both
+    ":work_dir                 | Temporary location where etest can place temporary files. This location will be both
                                  created and deleted by etest." \
     "@tests                    | Any number of individual tests, which may be executables to be executed and checked for
                                  exit code or may be files whose names end in .etest, in which case they will be sourced

--- a/share/opt.sh
+++ b/share/opt.sh
@@ -130,7 +130,7 @@ the name of the option. By convention, words are separated with hyphens in optio
 be characters in bash variables, so we use underscores in the variable name and automatically translate that to a hyphen
 in the option name.
 
-At present, ebash supports two different types of options: boolean and string.
+At present, ebash supports the following types of options:
 
 
 Boolean Options
@@ -164,18 +164,42 @@ argument, even if it is an empty string. In order to get a string option, you pr
     func()
     {
         $(opt_parse ":string s")
-        echo "STRING: X${string}X"
+        echo "STRING="${string}""
     }
 
     func --string "alpha"
-    # output -- STRING: XalphaX
+    # output: STRING="alpha"
     func --string ""
-    # output -- STRING: XX
+    # output: STRING=""
 
     func --string=alpha
-    # output -- STRING: XalphaX
+    # output: STRING="alpha"
     func --string=
-    # output -- STRING: XX
+    # output: STRING=""
+
+
+Non-Empty String Options
+------------------------
+
+Opt_parse also supports options whose value is a non-empty string. This is identical to a normal `:` string option only
+it is more strict since the string argument must be non-empty. In order to use this option, prepend its name with an
+equal character.
+
+    func()
+    {
+        $(opt_parse "=string s")
+        echo "STRING="${string}""
+    }
+
+    func --string "alpha"
+    # output: STRING="alpha"
+    func --string ""
+    # error: option --string requires a non-empty argument.
+
+    func --string=alpha
+    # output: STRING="alpha"
+    func --string=
+    # error: option --string requires a non-empty argument.
 
 
 Accumulator Values
@@ -317,7 +341,7 @@ opt_parse_setup()
         [[ -n ${opt_definition} ]] || die "${FUNCNAME[2]}: invalid opt_parse syntax. Option definition is empty."
 
         # Make sure this option definition looks right
-        [[ ${opt_definition} =~ ^([+:&?@])?([^=]+)(=.*)?$ ]]
+        [[ ${opt_definition} =~ ^([+:=&?@])?([^=]+)(=.*)?$ ]]
 
         # TYPE is the first character of the definition
         local opt_type_char=${BASH_REMATCH[1]}
@@ -347,12 +371,15 @@ opt_parse_setup()
         done
 
         # OPTIONS
-        if [[ ${opt_type_char} == @(:|&|+) ]] ; then
+        if [[ ${opt_type_char} == @(:|=|&|+) ]] ; then
 
             local name_regex=^\(${all_names//+( )/|}\)$
 
             if [[ ${opt_type_char} == ":" ]] ; then
                 opt_type="string"
+
+            elif [[ ${opt_type_char} == "=" ]] ; then
+                opt_type="nonempty_string"
 
             elif [[ ${opt_type_char} == "&" ]] ; then
                 opt_type="accumulator"
@@ -473,12 +500,17 @@ opt_parse_options()
                 canonical=$(opt_parse_find_canonical ${long_opt//-/_})
                 [[ -n ${canonical} ]] || die "${FUNCNAME[1]}: unexpected option --${long_opt}"
 
-                if [[ ${__EBASH_OPT_TYPE[$canonical]} == "string" ]] ; then
+                if [[ ${__EBASH_OPT_TYPE[$canonical]} == @(string|nonempty_string) ]] ; then
                     # If it wasn't specified after an equal sign, instead grab the next argument off the command line
                     if [[ -z ${has_arg} ]] ; then
-                        [[ $# -ge 2 ]] || die "${FUNCNAME[1]}: option --${long_opt} requires an argument but didn't receive one."
+                        [[ $# -ge 2 ]] || die "${FUNCNAME[1]}: option --${long_opt} requires an argument."
                         opt_arg=$2
                         shift && (( shift_count += 1 ))
+                    fi
+
+                    # If this is a nonempty_string assert it's non-empty
+                    if [[ ${__EBASH_OPT_TYPE[$canonical]} == "nonempty_string" && -z "${opt_arg}" ]]; then
+                        die "${FUNCNAME[1]}: option --${long_opt} requires a non-empty argument."
                     fi
 
                     __EBASH_OPT[$canonical]=${opt_arg}
@@ -486,7 +518,7 @@ opt_parse_options()
                 elif [[ ${__EBASH_OPT_TYPE[$canonical]} == "accumulator" ]]; then
                     # If it wasn't specified after an equal sign, instead grab the next argument off the command line
                     if [[ -z ${has_arg} ]] ; then
-                        [[ $# -ge 2 ]] || die "${FUNCNAME[1]}: option --${long_opt} requires an argument but didn't receive one."
+                        [[ $# -ge 2 ]] || die "${FUNCNAME[1]}: option --${long_opt} requires an argument."
                         opt_arg=$2
                         shift && (( shift_count += 1 ))
                     fi
@@ -535,8 +567,8 @@ opt_parse_options()
                     canonical=$(opt_parse_find_canonical ${char})
                     [[ -n ${canonical} ]] || die "${FUNCNAME[1]}: unexpected option --${long_opt}"
 
-                    if [[ ${__EBASH_OPT_TYPE[$canonical]} == "string" ]] ; then
-                        die "${FUNCNAME[1]}: option -${char} requires an argument but didn't receive one."
+                    if [[ ${__EBASH_OPT_TYPE[$canonical]} == @(string|nonempty_string) ]] ; then
+                        die "${FUNCNAME[1]}: option -${char} requires an argument."
                     fi
 
                     __EBASH_OPT[$canonical]=1
@@ -548,14 +580,18 @@ opt_parse_options()
                 [[ -n ${canonical} ]] || die "${FUNCNAME[1]}: unexpected option -${char}"
 
                 # If it expects an argument, make sure it has one and use it.
-                if [[ ${__EBASH_OPT_TYPE[$canonical]} == "string" ]] ; then
+                if [[ ${__EBASH_OPT_TYPE[$canonical]} == @(string|nonempty_string) ]] ; then
 
                     # If it wasn't specified after an equal sign, instead grab the next argument off the command line
                     if [[ -z ${has_arg} ]] ; then
-                        [[ $# -ge 2 ]] || die "${FUNCNAME[1]}: option -${char} requires an argument but didn't receive one."
-
+                        [[ $# -ge 2 ]] || die "${FUNCNAME[1]}: option --${long_opt} requires an argument."
                         opt_arg=$2
                         shift && (( shift_count += 1 ))
+                    fi
+
+                    # If this is a nonempty_string assert it's non-empty
+                    if [[ ${__EBASH_OPT_TYPE[$canonical]} == "nonempty_string" && -z "${opt_arg}" ]]; then
+                        die "${FUNCNAME[1]}: option --${long_opt} requires a non-empty argument."
                     fi
 
                     __EBASH_OPT[$canonical]=${opt_arg}
@@ -707,6 +743,8 @@ opt_display_usage()
 
                 # If the option accepts arguments, say that
                 [[ ${__EBASH_OPT_TYPE[$opt]} == "string" ]] && echo -n " <value>"
+                [[ ${__EBASH_OPT_TYPE[$opt]} == "nonempty_string" ]] && echo -n " <non-empty value>"
+
                 echo
 
                 # Print the docstring, constrained to current terminal width, indented another level past the option

--- a/share/opt.sh
+++ b/share/opt.sh
@@ -360,21 +360,18 @@ opt_parse_setup()
         local all_names=${BASH_REMATCH[2]}
         all_names=${all_names%%+([[:space:]])}
 
-        # DEFAULT VALUE is everything after the equal sign, excluding trailing
-        # whitespace
+        # DEFAULT VALUE is everything after the equal sign, excluding trailing whitespace
         local default=${BASH_REMATCH[3]#=}
         default=${default%%+([[:space:]])}
 
         # CANONICAL NAME is the first name specified
         local canonical=${all_names%%[ 	]*}
 
-        # It must be non-empty and must not contain hyphens (because hyphens
-        # are not allowed in bash variable names)
+        # It must be non-empty and must not contain hyphens (because hyphens are not allowed in bash variable names)
         [[ -n ${canonical} ]]      || die "${FUNCNAME[2]}: invalid opt_parse syntax. Name is empty."
         [[ ! ${canonical} = *-* ]] || die "${FUNCNAME[2]}: name ${canonical} is not allowed to contain hyphens."
 
-        # None of the option names are allowed override help, which is provided
-        # by opt_parse
+        # None of the option names are allowed override help, which is provided by opt_parse
         local name
         for name in ${all_names} ; do
             [[ "${name}" != "help" ]] || die "${FUNCNAME[2]}: The opt_parse help option cannot be overridden."
@@ -397,8 +394,8 @@ opt_parse_setup()
             elif [[ ${opt_type_char} == "+" ]] ; then
                 opt_type="boolean"
 
-                # Boolean options implicitly get a version whose name starts with
-                # no- that is a negation of the option. Adjust the name regex.
+                # Boolean options implicitly get a version whose name starts with no- that is a negation of the option.
+                # Adjust the name regex.
                 name_regex=${name_regex/^/^\(no_\)?}
 
                 # And forbid double-negative options
@@ -704,11 +701,15 @@ opt_display_usage()
             echo -n "Usage: ${FUNCNAME[1]} "
         fi
 
+        # Sort option keys so we can display options in sorted order.
+        local opt_keys=()
+        opt_keys=( $(echo ${!__EBASH_OPT[@]} | tr ' ' '\n' | sort) )
+
         # Display any REQUIRED options
         local opt
         local required_opts=()
         local entry
-        for opt in ${!__EBASH_OPT[@]} ; do
+        for opt in ${opt_keys[@]}; do
 
             if [[ ${__EBASH_OPT_TYPE[$opt]} != "required_string" ]]; then
                 continue
@@ -774,7 +775,7 @@ opt_display_usage()
             echo "(*) Denotes required options"
             echo ""
             local opt
-            for opt in ${!__EBASH_OPT[@]} ; do
+            for opt in ${opt_keys[@]}; do
 
                 # Print the names of all option "synonyms" next to each other
                 printf "   "

--- a/share/opt.sh
+++ b/share/opt.sh
@@ -707,10 +707,14 @@ opt_display_usage()
         # Display any REQUIRED options
         local opt
         local required_opts=()
+        local entry
         for opt in ${!__EBASH_OPT[@]} ; do
 
-            local entry=$(if [[ ${__EBASH_OPT_TYPE[$opt]} == "required_string" ]]; then
+            if [[ ${__EBASH_OPT_TYPE[$opt]} != "required_string" ]]; then
+                continue
+            fi
 
+            entry=$(
                 local synonym="" first=1
                 for synonym in ${__EBASH_OPT_SYNONYMS[$opt]} ; do
 
@@ -728,7 +732,7 @@ opt_display_usage()
                 done
 
                 echo -n " <non-empty value>"
-            fi)
+            )
 
             required_opts+=( $(string_trim "${entry}") )
         done

--- a/unittest/opt.etest
+++ b/unittest/opt.etest
@@ -163,7 +163,7 @@ ETEST_opt_parse_shorts_crammed_together_required_arg()
     }
 }
 
-ETEST_opt_parse_shorts_crammed_together_required_nonempty_missing_arg()
+ETEST_opt_parse_shorts_crammed_together_required_opt_missing_arg()
 {
     set -- -abc
     try
@@ -179,7 +179,23 @@ ETEST_opt_parse_shorts_crammed_together_required_nonempty_missing_arg()
     }
 }
 
-ETEST_opt_parse_shorts_crammed_together_required_nonempty_empty_arg()
+ETEST_opt_parse_shorts_crammed_together_required_opt_missing_opt()
+{
+    set -- -ab
+    try
+    {
+        $(opt_parse "+a" "+b" "=c")
+        etestmsg "$(opt_dump)"
+
+        die -r=243 "Should have failed when parsing options but did not."
+    }
+    catch
+    {
+        assert_ne 243 $?
+    }
+}
+
+ETEST_opt_parse_shorts_crammed_together_required_opt_empty_arg()
 {
     set -- -abc ""
     try

--- a/unittest/opt.etest
+++ b/unittest/opt.etest
@@ -102,6 +102,38 @@ ETEST_opt_parse_required_arg()
     }
 }
 
+ETEST_opt_parse_required_nonempty_missing_arg()
+{
+    set -- -a
+    try
+    {
+        $(opt_parse "=a")
+        etestmsg "$(opt_dump)"
+
+        die -r=243 "Should have failed parsing options."
+    }
+    catch
+    {
+        assert_ne 243 $?
+    }
+}
+
+ETEST_opt_parse_required_nonempty_empty_arg()
+{
+    set -- -a ""
+    try
+    {
+        $(opt_parse "=a")
+        etestmsg "$(opt_dump)"
+
+        die -r=243 "Should have failed parsing options."
+    }
+    catch
+    {
+        assert_ne 243 $?
+    }
+}
+
 ETEST_opt_parse_shorts_crammed_together_with_arg()
 {
     set -- -abc optarg arg
@@ -121,6 +153,38 @@ ETEST_opt_parse_shorts_crammed_together_required_arg()
     try
     {
         $(opt_parse "+a" "+b" ":c")
+        etestmsg "$(opt_dump)"
+
+        die -r=243 "Should have failed when parsing options but did not."
+    }
+    catch
+    {
+        assert_ne 243 $?
+    }
+}
+
+ETEST_opt_parse_shorts_crammed_together_required_nonempty_missing_arg()
+{
+    set -- -abc
+    try
+    {
+        $(opt_parse "+a" "+b" "=c")
+        etestmsg "$(opt_dump)"
+
+        die -r=243 "Should have failed when parsing options but did not."
+    }
+    catch
+    {
+        assert_ne 243 $?
+    }
+}
+
+ETEST_opt_parse_shorts_crammed_together_required_nonempty_empty_arg()
+{
+    set -- -abc ""
+    try
+    {
+        $(opt_parse "+a" "+b" "=c")
         etestmsg "$(opt_dump)"
 
         die -r=243 "Should have failed when parsing options but did not."
@@ -284,13 +348,14 @@ ETEST_opt_parse_recursive()
 
 ETEST_opt_parse_dump()
 {
-    set -- --alpha 10 --beta 20
-    $(opt_parse ":alpha" ":beta")
+    set -- --alpha 10 --beta 20 --gamma 30
+    $(opt_parse ":alpha" ":beta" "=gamma")
 
     etestmsg "$(opt_dump)"
 
     assert_eq 10 "${alpha}"
     assert_eq 20 "${beta}"
+    assert_eq 30 "${gamma}"
 
     local dump=""
     dump=$(opt_dump)
@@ -298,14 +363,15 @@ ETEST_opt_parse_dump()
     [[ "${dump}" =~ 10 ]]
     [[ "${dump}" =~ beta ]]
     [[ "${dump}" =~ 20 ]]
-
+    [[ "${dump}" =~ gamma ]]
+    [[ "${dump}" =~ 30 ]]
 }
 
 ETEST_opt_parse_without_options()
 {
     etestmsg "Trying to run opt_parse in a function that received no arguments or options"
     set --
-    $(opt_parse "+a" ":b" "+c=0")
+    $(opt_parse "+a" ":b" "+c=0" "=d=foobar")
     etestmsg "$(opt_dump)"
     etestmsg "Succcess."
 }
@@ -400,13 +466,15 @@ ETEST_opt_parse_boolean_validate()
 
 ETEST_opt_parse_args()
 {
-    set -- -o option one two more
+    set -- -o option -r required one two more
     $(opt_parse \
         ":option o" \
+        "=required r" \
         "arg1" \
         "arg2")
 
     assert_eq "option" "${option}"
+    assert_eq "required" "${required}"
     assert_eq "one" "${arg1}"
     assert_eq "two" "${arg2}"
     assert_eq 1 $#
@@ -473,6 +541,7 @@ ETEST_opt_parse_arg_optional()
 ETEST_opt_forward()
 {
     A_STRING="string with whitespace"
+    B_STRING="non-empty string"
     EXTRA1="EXTRA_1"
     EXTRA2="EXTRA  WITH  WHITESPACE"
 
@@ -483,10 +552,12 @@ ETEST_opt_forward()
         einfo "$(ecolor cyan)$(lval raw_args)"
         $(opt_parse \
             ":string"   \
+            "=required" \
             "+bool"     \
             "+other_bool")
         einfo "$(ecolor cyan)$(declare -p __EBASH_OPT)"
         assert_eq "${A_STRING}" "${string}"
+        assert_eq "${B_STRING}" "${required}"
         assert_eq 1 "${bool}"
         assert_eq 0 "${other_bool}"
     }
@@ -498,10 +569,12 @@ ETEST_opt_forward()
         einfo "$(ecolor orchid)$(lval raw_args)"
         $(opt_parse \
             ":string"   \
+            "=required" \
             "+bool"     \
             "+other_bool")
         einfo "$(ecolor orchid)$(declare -p __EBASH_OPT)"
         assert_eq "${A_STRING}" "${string}"
+        assert_eq "${B_STRING}" "${required}"
         assert_eq 1 "${bool}"
         assert_eq 0 "${other_bool}"
 
@@ -509,32 +582,32 @@ ETEST_opt_forward()
         assert_eq "$2" "${EXTRA2}"
     }
 
-
-
-    set -- --string "string with whitespace" --bool argument --no-other-bool
+    set -- --string "${A_STRING}" --required "${B_STRING}" --bool argument --no-other-bool
     local raw_args=( "$@" )
     einfo "$(ecolor green)$(lval raw_args)"
     $(opt_parse \
         ":string"   \
+        "=required" \
         "+bool"     \
         "+other_bool")
 
     einfo "$(ecolor green)$(declare -p __EBASH_OPT)"
     assert_eq "${A_STRING}" "${string}"
+    assert_eq "${B_STRING}" "${required}"
     assert_eq 1 "${bool}"
     assert_eq 0 "${other_bool}"
 
     etestmsg "calling subfunc"
-    opt_forward subfunc string bool other_bool
+    opt_forward subfunc string required bool other_bool
 
     etestmsg "Calling subfunc with hyphens"
-    opt_forward subfunc string bool other-bool
+    opt_forward subfunc string required bool other-bool
 
     etestmsg "calling subfunc with only -- after it"
-    opt_forward subfunc string bool --
+    opt_forward subfunc string required bool --
 
     etestmsg "calling subfunc_extra"
-    opt_forward subfunc_extra string bool -- "${EXTRA1}" "${EXTRA2}"
+    opt_forward subfunc_extra string required bool -- "${EXTRA1}" "${EXTRA2}"
 }
 
 ETEST_opt_forward_different_name()


### PR DESCRIPTION
This closes issue #24 by adding a new opt_parse type of `=` which is a required, non-empty string parameter. Also updates usage statements to show required options in `(...)` and annotate them with `(*)` in usage statement.

Also updates README and related tests.