### PR TITLE
Usage

### DIFF
--- a/bin/ebash
+++ b/bin/ebash
@@ -32,25 +32,6 @@
 #
 #-------------------------------------------------------------------------------
 
-
-# To be able to make good use of function documentation in places where we do something like this, we need to save
-# function documentation off into variables (or else we'd have to parse bash source code enough to extract it, which
-# sounds very error prone)
-#
-#     somefunc --help
-#
-# But we don't want to bloat the interpreter with a bunch of documentation every time we source ebash. Our solution is
-# to only save them at times where we believe the variables are going to be needed. There's no reason to expect they
-# will be necessary unless `--help` is on the command line somewhere. Or for those few cases where it's needed, they
-# can set this variable, too.
-#
-# And for this to work in all of the ebash files, we must do it before sourcing them.
-for arg in "$@" ; do
-    if [[ ${arg} == "--help" ]] ; then
-        __EBASH_SAVE_DOC=1
-    fi
-done
-
 : ${EBASH_HOME:=$(dirname $0)/..}
 : ${EBASH:=${EBASH_HOME}/share}
 source ${EBASH}/ebash.sh || { echo "Unable to source ${EBASH}/ebash.sh" ; exit 1 ; }

--- a/bin/etest
+++ b/bin/etest
@@ -7,7 +7,6 @@
 # published by the Apache Software Foundation, either version 2 of the License, or (at your option) any later version.
 
 : ${EMSG_PREFIX:=time}
-
 : ${EBASH_HOME:=$(dirname $0)/..}
 : ${EBASH:=${EBASH_HOME}/share}
 source ${EBASH}/ebash.sh || { echo "Unable to source ebash." ; exit 1 ; }
@@ -30,6 +29,30 @@ TOPDIR=${PWD}
 # GLOBAL SETUP
 #-----------------------------------------------------------------------------------------------------------------------
 
+opt_usage main <<'END'
+etest is an extensible test framework primarily focused at providing a rich test framework for bash complete with test
+suites and a rich set of test assertions and other various test related frameworks. It also supports running any
+standalone executable binaries or scripts written in any language. In this mode it is essentially a simple test driver.
+
+Tests can be grouped into test suites by placing them into a *.etest file. Each test is then a function inside that file
+with the naming scheme `ETEST_${suite}_${testcase}` (e.g. `ETEST_array_init` for the `array` suite and the testcase
+`init`). Each test suite *.etest file can contain optional `sutie_setup` and `suite_teardown` functions which are
+performed only once at the start and end of a suite, respectively. It can also optionally contain `setup` and
+`teardown` functions which are run before and after every single individual test.
+
+etest provides several additional security and auditing features of interest:
+
+    1) Every test is run in its own subshell to ensure process isolation.
+    2) Every test is run inside a unique cgroup (on Linux) to further isolate the process, mounts and networking from
+       the rest of the system.
+    3) Each test is monitored for process leaks and mount leaks.
+
+Tests can be repeated, filtered, excluded, debugged, traced and a host of other extensive developer friendly features.
+
+etest produces a JUnit/XUnit compatible etest.xml file at the end of the test run listing all the tests that were
+executed along with runtimes and specific lists of passing, failing and flaky tests. This file can be directly hooked
+into Jenkins, GitHub Actions, and BitBucket Pipelines for clear test visibility and reporting.
+END
 $(opt_parse \
     "+break   b=${BREAK:-0}    | Stop immediately on first failure." \
     "+clean   c=0              | Clean only and then exit." \

--- a/share/docker.sh
+++ b/share/docker.sh
@@ -11,6 +11,5 @@ Check if we are running inside docker or not.
 END
 running_in_docker()
 {
-    grep -qw docker /proc/$$/cgroup 2>/dev/null
+    [[ -f "/.dockerenv" ]] || grep -qw docker /proc/$$/cgroup 2>/dev/null
 }
-

--- a/share/ebash.sh
+++ b/share/ebash.sh
@@ -31,6 +31,22 @@ if [[ "$(ps -p $$ -ocomm=)" != "bash" ]]; then
     exec bash "$0" "${@}"
 fi
 
+# Automatic documentation
+#
+# All functions and ebash based scripts which utilize `opt_parse` get automatic documentation and usage information.
+# This is automatically available via `--help` or `-?` options. For this to work, we have to store off the docstrings
+# above each function into variables for subsequent output when the usage is requested via `--help` or `-?`.
+#
+# But we don't want to bloat the interpreter with a bunch of documentation every time we source ebash. Our solution is
+# to only save them at times where we believe the variables are going to be needed. There's no reason to expect they
+# will be necessary unless `--help` or `-?` is on the command line somewhere. Or for those few cases where it's needed,
+# for any other reason, the caller can just set `__EBASH_SAVE_DOC=1` explicitly.
+for arg in "$@" ; do
+    if [[ ${arg} == "--help" || ${arg} == "-?" ]] ; then
+        __EBASH_SAVE_DOC=1
+    fi
+done
+
 __EBASH_OS=$(uname)
 
 # Load configuration files

--- a/share/opt.sh
+++ b/share/opt.sh
@@ -771,13 +771,16 @@ opt_display_usage()
         # Finish the first line
         echo
 
-        # If there's a documentation block in memory for this function, display it. (Note: these only get saved when
-        # __EBASH_SAVE_DOC is set to 1 -- see ebash.sh)
-        if [[ -n "${__EBASH_DOC[${FUNCNAME[1]:-}]:-}" ]] ; then
+        # If there's a documentation block in memory for this function, display it.
+        # Note1: These only get saved when __EBASH_SAVE_DOC is set to 1 -- see ebash.sh)
+        # Note2: Newer code uses opt_parse_usage_name, but older code would have just used "main". We want to be
+        #        backwards compatible so we look for both.
+        if [[ -n "${__EBASH_DOC[$(opt_parse_usage_name)]:-}" ]] ; then
             printf -- "\n%s\n" "${__EBASH_DOC[$(opt_parse_usage_name)]}"
+        elif [[ "${FUNCNAME[1]:-}" == "main" && -n "${__EBASH_DOC["main"]:-}" ]] ; then
+            printf -- "\n%s\n" "${__EBASH_DOC["main"]}"
         fi
 
-        # Display block of documentation for options if there are any
         if [[ ${#__EBASH_OPT[@]} -gt 0 ]] ; then
             echo
             echo "Options:"


### PR DESCRIPTION
Fix ebash `--help` and `-?` to automatically include usage docstring without the need to set `__EBASH_SAVE_DOC` explicitly.

Also enhance `running_in_docker` to work properly when no docker cgroups are in use by looking for `/dockerenv` file