### PR TITLE
Add new transform option flag to dialog. Also automatically replace underscores

### DIFF
--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -32,8 +32,8 @@ jobs:
       fail-fast: false
       matrix:
         container:
+          - "alpine:3.13"
           - "alpine:3.12"
-          - "alpine:3.11"
           - "archlinux"
           - "centos:8"
           - "centos:7"

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ dshell-$1:
 endef
 
 DISTROS =			\
-	alpine:3.11		\
+	alpine:3.13		\
 	alpine:3.12		\
 	archlinux		\
 	centos:8		\

--- a/share/dialog.sh
+++ b/share/dialog.sh
@@ -245,10 +245,10 @@ dialog_prompt()
             display="${field^}"
         fi
 
-        # Change any underscores to spaces in the display field.
-        # Then apply any other custom replacements the caller asked for in the replace_label accumulator where each
-        # entry is a sed-style exppression.
-        display=$(echo "${display}" | sed -e "s|_\(.\)| \u\1|g")
+        # Split underscores and change them to spaces and uppercase the next character.
+        display=$(echo "${display}" | perl -pe 's/_([a-z])/ \U\1/g')
+
+        # Apply all custom replacements in the transform accumulator where each entry is a sed-style expression.
         local exp
         for exp in "${transform[@]}"; do
             edebug "Applying $(lval transform) to $(lval display)"
@@ -479,7 +479,7 @@ dialog_prompt()
         fi
 
         local dialog_output=""
-        dialog_output="$(string_trim "$(cat "${output_file}")")"
+        dialog_output="$(string_trim "$(tr -d '\0' < ${output_file})")"
         edebug "Dialog exited $(lval dialog_pid dialog_rc dialog_output)"
 
         if [[ ${dialog_rc} == ${DIALOG_CANCEL} ]]; then

--- a/share/dialog.sh
+++ b/share/dialog.sh
@@ -250,10 +250,8 @@ dialog_prompt()
 
         # Apply all custom replacements in the transform accumulator where each entry is a sed-style expression.
         local exp
-        for exp in "${transform[@]}"; do
-            edebug "Applying $(lval transform) to $(lval display)"
+        for exp in "${transform[@]:-}"; do
             display=$(echo "${display}" | sed -e "${exp}")
-            edebug "After transform $(lva display)"
         done
 
         # Ensure field name doesn't have any unsupported characters. It may not contain spaces, newlines or any special

--- a/unittest/dialog.etest
+++ b/unittest/dialog.etest
@@ -87,6 +87,25 @@ ETEST_dialog_prompt_single()
     assert_eq "Locke" "${philo1}"
 }
 
+# Verify fields are pretty printed by splitting on underscores and capitalizing each word.
+ETEST_dialog_prompt_pretty_print_fields()
+{
+    local input="192.168.0.1${EBASH_KEY_ENTER}${EBASH_KEY_DONE}"
+    $(printf "${input}" | ${DIALOG_PROMPT} ip_address ?user_name ?user_password 2> output)
+    grep "Ip Address" output
+    grep "User Name"  output
+    grep "User Password" output
+}
+
+# Verify we can customize field pretty-printing via --replace-label accumalator.
+ETEST_dialog_prompt_transform()
+{
+    local input="192.168.0.1${EBASH_KEY_ENTER}${EBASH_KEY_DONE}"
+    $(printf "${input}" | ${DIALOG_PROMPT} --transform "s|Ip|IP|g" --transform "s|Usb|USB|g" ip_address ?usb_device 2> output || true)
+    grep "IP Address" output
+    grep "USB Device" output
+}
+
 # Test multiple input fields. Also verifies that the down arrow key is used to seamlessly navigate between fields
 # without having to press ENTER to exit the first field and enter the second field.
 ETEST_dialog_prompt_multi()

--- a/unittest/opt.etest
+++ b/unittest/opt.etest
@@ -877,6 +877,13 @@ ETEST_opt_parse_accumulator_single()
     assert_eq "apples" "${files[0]}"
 }
 
+ETEST_opt_parse_accumalator_empty()
+{
+    $(opt_parse "&files")
+    etestmsg "$(opt_dump)"
+    assert_zero "$(array_size files)"
+}
+
 ETEST_argcheck()
 {
     try


### PR DESCRIPTION
This changes dialog_prompt to automatically replace underscores with spaces in the labels. It also uppercases each word.

But it takes it further and provides a new `--transform` accumulator (which means you can provide it multiple times and it builds them up into an array) of sed style expressions to be applied to the labels. This way you can customize the behavior of the label replacements as needed.