### PR TITLE
Dialog fixes

### DIFF
--- a/share/dialog.sh
+++ b/share/dialog.sh
@@ -160,34 +160,29 @@ window. But the caller is always allowed to override this with the --geometry op
 END
 dialog_prompt()
 {
+    local default_title="\nPlease provide the following information.\n"
     $(opt_parse \
-        "+global                                           | Emit global variables instead of local ones."             \
-        "+export                                           | Emit exported variables instead of local ones."           \
-        "+instructions                                     | Include instructions on how to navigate dialog window."   \
-        ":backtitle                                        | Text to display on backdrop at top left of the screen."   \
-        ":geometry                                         | Geometry of the box (HEIGHTxWIDTHxMENU-HEIGHT). "         \
-        ":help_label                                       | Override label used for 'Help' button."                   \
-        ":help_callback                                    | Callback to invoke when 'Help' button is pressed."        \
-        "+hide                                             | Hide ncurses output from screen (useful for testing)."    \
-        ":title=Please provide the following information   | String to display as the top of the dialog box."          \
-        "+trace                                            | If enabled, enable extensive dialog debugging to stderr." \
-        "&transform                                        | Accumulator of sed-like replace expressions to perform on
-                                                             dialog labels. Expressions are 's/regexp/replace/[flags]'
-                                                             where regexp is a regular expression and replace is a
-                                                             replacement for each label that matches regexp. For more
-                                                             details see the sed manpage."                             \
-        "@fields                                           | List of option fields to prompt for. Field names may not
-                                                             contain spaces, newlines or special punctuation characters.")
+        "+declare=1              | Declare variables before assigning to them. This is almost always required unless the
+                                   caller has already declared the variables before calling into dialog_prompt and
+                                   disires to simply reuse the existing variables."                                    \
+        "+instructions           | Include instructions on how to navigate dialog window."                             \
+        ":backtitle              | Text to display on backdrop at top left of the screen."                             \
+        ":geometry               | Geometry of the box (HEIGHTxWIDTHxMENU-HEIGHT)."                                    \
+        ":help_label             | Override label used for 'Help' button."                                             \
+        ":help_callback          | Callback to invoke when 'Help' button is pressed."                                  \
+        "+hide                   | Hide ncurses output from screen (useful for testing)."                              \
+        ":title=${default_title} | String to display as the top of the dialog box."                                    \
+        "+trace                  | If enabled, enable extensive dialog debugging to stderr."                           \
+        "&transform              | Accumulator of sed-like replace expressions to perform on dialog labels. Expressions
+                                   are 's/regexp/replace/[flags]' where regexp is a regular expression and replace is a
+                                   replacement for each label matching regexp. For more details see the sed manpage."  \
+        "@fields                 | List of option fields to prompt for. Field names may not contain spaces, newlines or
+                                   special punctuation characters.")
 
     # Ensure at least one field was prompted for
     if array_empty fields; then
         die "Must prompt for at least one field."
     fi
-
-    # Determine flags to pass into declare
-    local declare_flags=""
-    [[ ${global} -eq 1 ]] && declare_flags="-g"
-    [[ ${export} -eq 1 ]] && declare_flags="-gx"
 
     # We're creating an "eval command string" inside the command substitution the caller wraps around dialog_prompt.
     #
@@ -405,13 +400,6 @@ dialog_prompt()
             # of the window. So here we essentially update the default_button.
             if [[ "${char}" == "${EBASH_KEY_TAB}" && ${focus} -ne 1 ]]; then
 
-                # Ignore TAB if we're in the middle of an input field as it's not clear if the expectation is to
-                # insert a literal tab character into the input field or to navigate down to the bottom menu. Doing
-                # any kind of automatic navigation is sloppy and confusing for the user.
-                if [[ ${focus} -eq 1 ]]; then
-                    continue
-                fi
-
                 if [[ ${default_button} == "extra" ]]; then
                     default_button="ok"
                 elif [[ ${default_button} == "ok" ]]; then
@@ -446,8 +434,10 @@ dialog_prompt()
                     focus=0
                     echo "" > "${input_file}"
 
-                    if [[ "${char}" == ${EBASH_KEY_DOWN} || "${char}" == ${EBASH_KEY_ENTER} || "${char}" == "${EBASH_KEY_TAB}" ]]; then
+                    if [[ "${char}" == ${EBASH_KEY_DOWN} || "${char}" == ${EBASH_KEY_ENTER} ]]; then
                         offset=1
+                    elif [[ "${char}" == "${EBASH_KEY_TAB}" ]]; then
+                        default_button="ok"
                     elif [[ "${char}" == "${EBASH_KEY_UP}" ]]; then
                         offset=-1
                     fi
@@ -517,7 +507,9 @@ dialog_prompt()
 
                     next=$((idx+${offset}))
                     if [[ ${next} -ge ${#keys[@]} ]]; then
-                        next=$(( ${#keys[@]} -1 ))
+                        next=0
+                        default_button="ok"
+                        break
                     elif [[ ${next} -lt 0 ]]; then
                         next=0
                     fi
@@ -537,7 +529,7 @@ dialog_prompt()
             local missing=()
             for key in "${keys[@]}"; do
                 if [[ $(pack_get fpack[$key] required) -eq 1 && -z $(pack_get fpack[$key] value) ]]; then
-                    missing+=( $(pack_get fpack[$key] display | sed 's|^*||') )
+                    missing+=( "$(pack_get fpack[$key] display | sed 's|^*||')" )
                 fi
             done
 
@@ -553,12 +545,17 @@ dialog_prompt()
     done
 
     # Export final values for caller
-    echo "eval declare ${declare_flags} dialog_rc=${dialog_rc};"
+    echo "eval declare dialog_rc=${dialog_rc};"
     for key in "${keys[@]}"; do
         edebug "${key}=>$(pack_get fpack[$key] value)"
         local value=""
         value=$(printf %q "$(printf "%q" "$(pack_get fpack[$key] value)")")
-        echo "eval declare ${declare_flags} ${key}=${value};"
+
+        if [[ "${declare}" -eq 1 ]]; then
+            echo "eval declare ${key}=${value};"
+        else
+            echo "eval ${key}=${value};"
+        fi
     done
 
     # Clean-up
@@ -579,17 +576,13 @@ dialog_prompt_username_password()
 {
     local default_title="\nPlease provide login information.\n"
     $(opt_parse \
-        "+global   g             | Emit global variables instead of local ones."                                       \
-        "+export   e             | Emit exported variables instead of local ones."                                     \
+        "+declare=1              | Declare variables before assigning to them. This is almost always required unless the
+                                   caller has already declared the variables before calling into dialog_prompt and
+                                   disires to simly reuse the existing variables."                                     \
         "+optional o             | If true, the username and password are optional. In this case the user will be
                                    allowed to exit the dialog menu without providing username and passwords. Otherwise
                                    it will sit in a loop until the user provides both values."                         \
         ":title=${default_title} | Title to put at the top of the dialog box.")
-
-    # Determine flags to pass into declare
-    local declare_flags=""
-    [[ ${global} -eq 1 ]] && declare_flags="-g"
-    [[ ${export} -eq 1 ]] && declare_flags="-gx"
 
     # We're creating an "eval command string" inside the command substitution the caller wraps around dialog_prompt.
     #
@@ -631,9 +624,12 @@ dialog_prompt_username_password()
         #
         # In particular, passwords that begin with '$' cause bash to evaluate the password as a variable name (and
         # it would usually fail with a complaint that the varialbe was unbound).
-        echo "eval declare ${declare_flags} username password; "
+        if [[ "${declare}" -eq 1 ]]; then
+            echo "eval declare username password; "
+        fi
         echo "eval username=$(printf %q "${username}"); "
         echo "eval password=$(printf \'%q\' "${password}"); "
+
         return 0
     done
 }

--- a/share/signal.sh
+++ b/share/signal.sh
@@ -27,7 +27,7 @@ disable_signals()
 
 reenable_signals()
 {
-    eval "${_EBASH_SAVED_TRAPS[$BASHPID]}"
+    eval "${_EBASH_SAVED_TRAPS[$BASHPID]:-}"
 }
 
 opt_usage signum <<'END'

--- a/share/signal.sh
+++ b/share/signal.sh
@@ -27,7 +27,9 @@ disable_signals()
 
 reenable_signals()
 {
-    eval "${_EBASH_SAVED_TRAPS[$BASHPID]:-}"
+    if array_not_empty _EBASH_SAVED_TRAPS; then
+        eval "${_EBASH_SAVED_TRAPS[$BASHPID]}"
+    fi
 }
 
 opt_usage signum <<'END'

--- a/unittest/dialog.etest
+++ b/unittest/dialog.etest
@@ -101,8 +101,8 @@ ETEST_dialog_prompt_pretty_print_fields()
 {
     local input="192.168.0.1${EBASH_KEY_ENTER}${EBASH_KEY_DONE}"
     $(printf "${input}" | ${DIALOG_PROMPT} ip_address ?user_name ?user_password 2> output)
-    grep "Ip Address" output
-    grep "User Name"  output
+    grep "Ip Address"    output
+    grep "User Name"     output
     grep "User Password" output
 }
 
@@ -191,8 +191,18 @@ ETEST_dialog_prompt_default_values()
 ETEST_dialog_prompt_default_values_override()
 {
     # Since we intend to overwrite the existing values we need to delete the keys already present.
-    local input="${EBASH_KEY_DELETE}Thomas Jefferson${EBASH_KEY_DOWN}${EBASH_KEY_DOWN}${EBASH_KEY_DELETE}John Rawls${EBASH_KEY_ENTER}${EBASH_KEY_DONE}"
-    $(printf "${input}" | ${DIALOG_PROMPT} "?philo1=A" "?philo2=Kant" "?philo3=_")
+     local input=(
+        "${EBASH_KEY_DELETE}"
+        "Thomas Jefferson"
+        "${EBASH_KEY_DOWN}"
+        "${EBASH_KEY_DOWN}"
+        "${EBASH_KEY_DELETE}"
+        "John Rawls"
+        "${EBASH_KEY_TAB}"
+        "${EBASH_KEY_ENTER}"
+    )
+
+    $(printf %s "${input[@]/#/}" | ${DIALOG_PROMPT} "?philo1=A" "?philo2=Kant" "?philo3=_")
     assert_eq "Thomas Jefferson" "${philo1}"
     assert_eq "Kant"             "${philo2}"
     assert_eq "John Rawls"       "${philo3}"
@@ -215,7 +225,6 @@ ETEST_dialog_prompt_default_values_override_term()
 
     # Since we intend to overwrite the existing values we need to delete the keys already present.
     local input="${EBASH_KEY_DELETE}Thomas Jefferson${EBASH_KEY_DOWN}${EBASH_KEY_DOWN}${EBASH_KEY_DELETE}John Rawls${EBASH_KEY_TAB}${EBASH_KEY_DONE}"
-    #local input="${EBASH_KEY_DELETE}Thomas Jefferson${EBASH_KEY_DOWN}${EBASH_KEY_DOWN}${EBASH_KEY_DELETE}John Rawls${EBASH_KEY_ENTER}${EBASH_KEY_DONE}"
     $(printf "${input}" | ${DIALOG_PROMPT} "?philo1=A" "?philo2=Kant" "?philo3=_")
     assert_eq "Thomas Jefferson" "${philo1}"
     assert_eq "Kant"             "${philo2}"

--- a/unittest/dialog.etest
+++ b/unittest/dialog.etest
@@ -80,39 +80,20 @@ ETEST_dialog_read_term()
 # Setup flags we want to use for all these tests
 DIALOG_PROMPT="dialog_prompt --hide --trace"
 
+# Global variable to ensure we can set this using non-declare option
+non_declared_username=""
+ETEST_dialog_prompt_no_declare()
+{
+    local input="Mando${EBASH_KEY_ENTER}${EBASH_KEY_DONE}"
+    $(printf "${input}" | ${DIALOG_PROMPT} --no-declare non_declared_username)
+    assert_eq "Mando" "${non_declared_username}"
+}
+
 ETEST_dialog_prompt_single()
 {
     local input="Locke${EBASH_KEY_ENTER}${EBASH_KEY_DONE}"
     $(printf "${input}" | ${DIALOG_PROMPT} philo1)
     assert_eq "Locke" "${philo1}"
-}
-
-ETEST_dialog_prompt_export()
-{
-    local expect="Calvin and Hobbes"
-    local input="${expect}${EBASH_KEY_ENTER}${EBASH_KEY_DONE}"
-    $(printf "${input}" | ${DIALOG_PROMPT} --export name)
-    assert_eq "${expect}" "${name}"
-
-    local actual
-    actual="$(declare -p name)"
-    assert_eq "declare -x name=\"${expect}\"" "${actual}"
-}
-
-ETEST_dialog_prompt_global()
-{
-    declare -g name=""
-    local expect="Calvin and Hobbes"
-    local input="${expect}${EBASH_KEY_ENTER}${EBASH_KEY_DONE}"
-
-    # If this is a global variable, then changing it inside this function will have the changes persistant outside.
-    run()
-    {
-        $(printf "${input}" | ${DIALOG_PROMPT} --global name)
-    }
-
-    run
-    assert_eq "${expect}" "${name}"
 }
 
 # Verify fields are pretty printed by splitting on underscores and capitalizing each word.
@@ -217,11 +198,8 @@ ETEST_dialog_prompt_default_values_override()
     assert_eq "John Rawls"       "${philo3}"
 }
 
-ETEST_dialog_prompt_default_values_override_term()
+ETEST_dialog_prompt_default_values_override_tab()
 {
-    export TERM=linux
-    dialog_load
-
     # Since we intend to overwrite the existing values we need to delete the keys already present.
     local input="${EBASH_KEY_DELETE}Thomas Jefferson${EBASH_KEY_DOWN}${EBASH_KEY_DOWN}${EBASH_KEY_DELETE}John Rawls${EBASH_KEY_TAB}${EBASH_KEY_DONE}"
     $(printf "${input}" | ${DIALOG_PROMPT} "?philo1=A" "?philo2=Kant" "?philo3=_")
@@ -230,6 +208,80 @@ ETEST_dialog_prompt_default_values_override_term()
     assert_eq "John Rawls"       "${philo3}"
 }
 
+ETEST_dialog_prompt_default_values_override_term()
+{
+    export TERM=linux
+    dialog_load
+
+    # Since we intend to overwrite the existing values we need to delete the keys already present.
+    local input="${EBASH_KEY_DELETE}Thomas Jefferson${EBASH_KEY_DOWN}${EBASH_KEY_DOWN}${EBASH_KEY_DELETE}John Rawls${EBASH_KEY_TAB}${EBASH_KEY_DONE}"
+    #local input="${EBASH_KEY_DELETE}Thomas Jefferson${EBASH_KEY_DOWN}${EBASH_KEY_DOWN}${EBASH_KEY_DELETE}John Rawls${EBASH_KEY_ENTER}${EBASH_KEY_DONE}"
+    $(printf "${input}" | ${DIALOG_PROMPT} "?philo1=A" "?philo2=Kant" "?philo3=_")
+    assert_eq "Thomas Jefferson" "${philo1}"
+    assert_eq "Kant"             "${philo2}"
+    assert_eq "John Rawls"       "${philo3}"
+}
+
+# Basic sanity test around menu navigation
+ETEST_dialog_prompt_navigation()
+{
+    local input=(
+        "${EBASH_KEY_DOWN}"
+        "${EBASH_KEY_DOWN}"
+        "${EBASH_KEY_UP}"
+        "${EBASH_KEY_UP}"
+        "Linus Torvalds"
+        "${EBASH_KEY_ENTER}"
+        "${EBASH_KEY_TAB}"
+        "${EBASH_KEY_TAB}"
+        "Tove Torvalds"
+        "${EBASH_KEY_ENTER}"
+        "${EBASH_KEY_TAB}"
+        "${EBASH_KEY_ENTER}"
+    )
+
+    $(printf %s "${input[@]/#/}" | ${DIALOG_PROMPT} "name1" "name2" "?name3")
+
+    assert_eq "Linus Torvalds" "${name1}"
+    assert_eq "Tove Torvalds" "${name2}"
+    assert_eq ""              "${name3}"
+}
+
+# Additional test with navigation mixed with character deletions
+ETEST_dialog_prompt_navigation_with_delete()
+{
+    # Expected values we're going to use
+    declare -A expect=(
+        [hostname]="etest-$$"
+        [ip]="1.1.1.1"
+    )
+
+    # Mock out hostname
+    hostname()
+    {
+        echo "${expect[hostname]}"
+    }
+
+    # Construct a string of deletions to delete the default hostname we're going to use
+    local delete_hostname=""
+    for (( idx=0; idx < ${#expect[hostname]}; idx++ )); do
+        delete_hostname+="${EBASH_KEY_DELETE}"
+    done
+
+    local input=(
+        "${delete_hostname}"
+        "${expect[hostname]}"
+        "${EBASH_KEY_DOWN}"
+        "${expect[ip]}"
+        "${EBASH_KEY_DOWN}"
+        "${EBASH_KEY_ENTER}"
+    )
+
+    $(printf %s "${input[@]/#/}" | ${DIALOG_PROMPT} "hostname" "ip")
+
+    assert_eq "${expect[hostname]}" "${hostname}"
+    assert_eq "${expect[ip]}"       "${ip}"
+}
 
 # Wherever we are in the dialog menu, escape key should take us out immediately.
 ETEST_dialog_prompt_escape()


### PR DESCRIPTION
    SO many fixes to dialog layer:
    
    - Remove export and global flags in dialog_prompt as it's not needed
    - Instead add new declare option flag. Allowing caller to opt-out of variable declaration.
    - MASSIVE fixes to flow of tab through interface. When you hit tab it now goes to OK button
      instead of EDIT to avoid a double-tab at the end.
    - When you hit the last field in the input window, if you hit down arrow it takes you down
      to the OK/Edit/Cancel buttons.
