### PR TITLE
Addresses ebash issue 4 to add new etable_values function.

### DIFF
--- a/share/etable.sh
+++ b/share/etable.sh
@@ -330,3 +330,103 @@ __etable_internal_html()
     echo "    </tbody>"
     echo "</table>"
 }
+
+opt_usage etable_values <<'END'
+etable_values is a special-purpose wrapper around etable which makes it easier to create an etable with a provided list
+of values and formats it into two columns, one showing the KEY and one showing the VALUE. For each variable, if it is a
+string or an array it will be expanded into the value as you'd expect. If the variable is an associative array or a
+pack, the keys and values will be unpacked and displayed in the KEY/VALUE columns in an exploded manner. This function
+relies on print_value() for pretty printing individual values. Specifically:
+
+    1) Strings: "value with spaces"
+    2) Arrays:  ("value with spaces" "Something" "1")
+
+For example, if you passed in:
+
+    $ etable_values HOME USER
+
+This would produce
+
+    +------+------------------+
+    | Key  | Value            |
+    +------+------------------+
+    | HOME | "/home/marshall" |
+    | USER | "marshall"       |
+    +------+------------------+
+
+If you have an associative array:
+
+    $ declare -A data([key1]="value1" [key2]="value2")
+    $ etable_values data
+
+This would produce
+
+    +------+----------+
+    | Key  | Value    |
+    +------+----------+
+    | key1 | "value1" |
+    | key2 | "value2" |
+    +------+----------+
+
+Similar to ebanner there is an --uppercase and a --lowercase if you want to have all the keys in all uppercase or
+lowercase for consistency.
+END
+etable_values()
+{
+    local default_columns="Key|Value"
+    $(opt_parse \
+        ":style          | Table style (ascii, html, boxart). Default=ascii."         \
+        "+rowlines       | Display a separator line in between each row."             \
+        "+column_delim=1 | Display column delimiters."                                \
+        ":columns        | Column headers for the table (default=${default_columns}." \
+        "+uppercase      | Uppercase all keys for display consistency."               \
+        "+lowercase      | Lowercase all keys for display consistency."               \
+        "+sort=1         | Sort keys in the tabular output."                          \
+        "@entries        | Array of variables to display the values of.")
+
+    : ${columns:="${default_columns}"}
+    local rows=()
+
+    # Helper function to determine display key to use
+    display_key()
+    {
+        local original_key="${1}"
+        if [[ ${uppercase} -eq 1 ]]; then
+            echo "${original_key^^}"
+        elif [[ ${lowercase} -eq 1 ]]; then
+            echo "${original_key,,}"
+        else
+            echo "${original_key}"
+        fi
+    }
+
+    local __entry __key
+    for __entry in "${entries[@]}"; do
+
+        if is_associative_array "${__entry}"; then
+            for __key in $(array_indexes_sort ${__entry}); do
+                eval 'array_add_nl rows "'$(display_key ${__key})'|${'${__entry}'['${__key}']}"'
+            done
+
+        elif is_pack "${__entry}"; then
+            for __key in $(pack_keys_sort ${__entry#%}); do
+                array_add_nl rows "$(display_key ${__key})|$(pack_get ${__entry#%} ${__key})"
+            done
+        elif is_array "${__entry}"; then
+            array_add_nl rows "$(display_key ${__entry})|$(print_value ${__entry})"
+        else
+            eval 'array_add_nl rows "'$(display_key ${__entry})'|${'${__entry}'}"'
+        fi
+    done
+
+    if [[ ${sort} -eq 1 ]]; then
+        array_sort rows
+    fi
+
+    # We add in the column headers after we've added all the rows so it doesn't get sorted amongst the actual rows.
+    rows=( "${columns}" "${rows[@]}" )
+
+    # Forward everything to actual etable function.
+    opt_forward etable style rowlines column_delim -- "${rows[@]}"
+}
+

--- a/share/etable.sh
+++ b/share/etable.sh
@@ -336,10 +336,7 @@ etable_values is a special-purpose wrapper around etable which makes it easier t
 of values and formats it into two columns, one showing the KEY and one showing the VALUE. For each variable, if it is a
 string or an array it will be expanded into the value as you'd expect. If the variable is an associative array or a
 pack, the keys and values will be unpacked and displayed in the KEY/VALUE columns in an exploded manner. This function
-relies on print_value() for pretty printing individual values. Specifically:
-
-    1) Strings: "value with spaces"
-    2) Arrays:  ("value with spaces" "Something" "1")
+relies on print_value() for pretty printing arrays.
 
 For example, if you passed in:
 
@@ -347,12 +344,12 @@ For example, if you passed in:
 
 This would produce
 
-    +------+------------------+
-    | Key  | Value            |
-    +------+------------------+
-    | HOME | "/home/marshall" |
-    | USER | "marshall"       |
-    +------+------------------+
+    +------+----------------+
+    | Key  | Value          |
+    +------+----------------+
+    | HOME | /home/marshall |
+    | USER | marshall       |
+    +------+----------------+
 
 If you have an associative array:
 
@@ -361,12 +358,24 @@ If you have an associative array:
 
 This would produce
 
-    +------+----------+
-    | Key  | Value    |
-    +------+----------+
-    | key1 | "value1" |
-    | key2 | "value2" |
-    +------+----------+
+    +------+--------+
+    | Key  | Value  |
+    +------+--------+
+    | key1 | value1 |
+    | key2 | value2 |
+    +------+--------+
+
+With a pack:
+
+    $ pack_set data key1="value1" key2="value2"
+    $ etable_values %data
+
+    +------+--------+
+    | Key  | Value  |
+    +------+--------+
+    | key1 | value1 |
+    | key2 | value2 |
+    +------+--------+
 
 Similar to ebanner there is an --uppercase and a --lowercase if you want to have all the keys in all uppercase or
 lowercase for consistency.

--- a/share/pack.sh
+++ b/share/pack.sh
@@ -207,6 +207,14 @@ pack_keys()
     echo "${!1:-}" | _unpack | sed 's/=.*$//'
 }
 
+opt_usage pack_keys_sort <<'END'
+Echo a whitespace-separated list of the sorted keys in the specified pack to stdout.
+END
+pack_keys_sort()
+{
+    pack_keys "${@}" | sort
+}
+
 opt_usage pack_print <<'END'
 Note: To support working with print_value, pack_print does NOT print a newline at the end of its output
 END

--- a/unittest/etable.etest
+++ b/unittest/etable.etest
@@ -474,3 +474,155 @@ ETEST_etable_boxart_title_no_internal_lines_with_headers()
 
     diff --unified expect actual
 }
+
+ETEST_etable_values()
+{
+    KEY1="Value With Spaces 1"
+    KEY2="Value With Spaces 2"
+    etable_values KEY1 KEY2 > actual
+
+    cat actual
+
+    cat >expect <<-END
+	+------+---------------------+
+	| Key  | Value               |
+	+------+---------------------+
+	| KEY1 | Value With Spaces 1 |
+	| KEY2 | Value With Spaces 2 |
+	+------+---------------------+
+	END
+
+    diff --unified expect actual
+}
+
+ETEST_etable_values_columns()
+{
+    KEY1="Value With Spaces 1"
+    KEY2="Value With Spaces 2"
+    etable_values --columns "Parameter|Value" KEY1 KEY2 > actual
+
+    cat actual
+
+    cat >expect <<-END
+	+-----------+---------------------+
+	| Parameter | Value               |
+	+-----------+---------------------+
+	| KEY1      | Value With Spaces 1 |
+	| KEY2      | Value With Spaces 2 |
+	+-----------+---------------------+
+	END
+
+    diff --unified expect actual
+}
+
+
+ETEST_etable_values_associative_array()
+{
+    KEY1="Value With Spaces 1"
+    KEY2="Value With Spaces 2"
+    declare -A data=([dkey1]="Calvin and Hobbes" [dkey2]="Calvin and Suzie" [dkey3]="Fourty-Two")
+    etable_values --uppercase KEY1 KEY2 data > actual
+
+    cat actual
+
+    cat >expect <<-END
+	+-------+---------------------+
+	| Key   | Value               |
+	+-------+---------------------+
+	| DKEY1 | Calvin and Hobbes   |
+	| DKEY2 | Calvin and Suzie    |
+	| DKEY3 | Fourty-Two          |
+	| KEY1  | Value With Spaces 1 |
+	| KEY2  | Value With Spaces 2 |
+	+-------+---------------------+
+	END
+
+    diff --unified expect actual
+}
+
+ETEST_etable_values_associative_array_nosort()
+{
+    KEY1="Value With Spaces 1"
+    KEY2="Value With Spaces 2"
+    declare -A data=([dkey1]="Calvin and Hobbes" [dkey2]="Calvin and Suzie" [dkey3]="Fourty-Two")
+    app="foo"
+    etable_values --no-sort KEY1 KEY2 data app > actual
+
+    cat actual
+
+    cat >expect <<-END
+	+-------+---------------------+
+	| Key   | Value               |
+	+-------+---------------------+
+	| KEY1  | Value With Spaces 1 |
+	| KEY2  | Value With Spaces 2 |
+	| dkey1 | Calvin and Hobbes   |
+	| dkey2 | Calvin and Suzie    |
+	| dkey3 | Fourty-Two          |
+	| app   | foo                 |
+	+-------+---------------------+
+	END
+
+    diff --unified expect actual
+}
+
+
+ETEST_etable_values_array_pack()
+{
+    KEY1="Value With Spaces 1"
+    KEY2="Value With Spaces 2"
+    declare -A data=([dkey1]="Calvin and Hobbes" [dkey2]="Calvin and Suzie" [dkey3]="Fourty-Two")
+    declare -a values=("array #1" "array #2" "array #3")
+    pack_set pack FNAME="my-file.txt" SIZE="1024" MD5="86f52cf9433ced9f6e1619d66e1a50f6"
+    etable_values --lowercase KEY1 KEY2 data values %pack > actual
+
+    cat actual
+
+    cat >expect <<-END
+	+--------+------------------------------------+
+	| Key    | Value                              |
+	+--------+------------------------------------+
+	| dkey1  | Calvin and Hobbes                  |
+	| dkey2  | Calvin and Suzie                   |
+	| dkey3  | Fourty-Two                         |
+	| fname  | my-file.txt                        |
+	| key1   | Value With Spaces 1                |
+	| key2   | Value With Spaces 2                |
+	| md5    | 86f52cf9433ced9f6e1619d66e1a50f6   |
+	| size   | 1024                               |
+	| values | ("array #1" "array #2" "array #3") |
+	+--------+------------------------------------+
+	END
+
+    diff --unified expect actual
+}
+
+ETEST_etable_values_array_pack_boxart()
+{
+    KEY1="Value With Spaces 1"
+    KEY2="Value With Spaces 2"
+    declare -A data=([dkey1]="Calvin and Hobbes" [dkey2]="Calvin and Suzie" [dkey3]="Fourty-Two")
+    declare -a values=("array #1" "array #2" "array #3")
+    pack_set pack FNAME="my-file.txt" SIZE="1024" MD5="86f52cf9433ced9f6e1619d66e1a50f6"
+    etable_values --lowercase --style=boxart KEY1 KEY2 data values %pack > actual
+
+    cat actual
+
+    cat >expect <<-END
+	┌────────┬────────────────────────────────────┐
+	│ Key    │ Value                              │
+	├────────┼────────────────────────────────────┤
+	│ dkey1  │ Calvin and Hobbes                  │
+	│ dkey2  │ Calvin and Suzie                   │
+	│ dkey3  │ Fourty-Two                         │
+	│ fname  │ my-file.txt                        │
+	│ key1   │ Value With Spaces 1                │
+	│ key2   │ Value With Spaces 2                │
+	│ md5    │ 86f52cf9433ced9f6e1619d66e1a50f6   │
+	│ size   │ 1024                               │
+	│ values │ ("array #1" "array #2" "array #3") │
+	└────────┴────────────────────────────────────┘
+	END
+
+    diff --unified expect actual
+}


### PR DESCRIPTION
Adds new `etable_values` function to make it super simple to create an etable using a simple list of variables to generate a key/value table. Also seamlessly supports arrays, associative arrays, and packs (with required '%' in front of pack variable name).

Operates on variables only similar to `ebanner` and `lval`. !! So much safer and easier to use.

Also supports sorting the keys, uppercase them, and lowercasing them!

