### PR TITLE
Fix for emock

### DIFF
--- a/share/emock.sh
+++ b/share/emock.sh
@@ -143,19 +143,20 @@ emock()
         statedir="'${statedir}'"
 
         # Update call count
-        called=0
+        called=1
         if [[ -e "${statedir}/called" ]]; then
             called=$(cat "${statedir}/called")
             (( called++ ))
-        fi
-        echo ${called} > "${statedir}/called"
-
+        fi 
+   
         # Create directory to store files in for this invocation
         mkdir -p "${statedir}/${called}"
 
         # Save off timestamp and argument array
         echo -en $(date "+%FT%TZ") > "${statedir}/${called}/timestamp"
         printf "\"%s\" " "${@}" > "${statedir}/${called}/args"
+        
+        echo ${called} > "${statedir}/called"
     '
 
     # Create the mock

--- a/share/emock.sh
+++ b/share/emock.sh
@@ -148,14 +148,12 @@ emock()
             called=$(cat "${statedir}/called")
             (( called++ ))
         fi 
-   
         # Create directory to store files in for this invocation
         mkdir -p "${statedir}/${called}"
 
         # Save off timestamp and argument array
         echo -en $(date "+%FT%TZ") > "${statedir}/${called}/timestamp"
         printf "\"%s\" " "${@}" > "${statedir}/${called}/args"
-        
         echo ${called} > "${statedir}/called"
     '
 

--- a/share/emock.sh
+++ b/share/emock.sh
@@ -148,13 +148,14 @@ emock()
             called=$(cat "${statedir}/called")
             (( called++ ))
         fi 
-        # Create directory to store files in for this invocation
+        echo ${called} > "${statedir}/called"
+ 
+       # Create directory to store files in for this invocation
         mkdir -p "${statedir}/${called}"
 
         # Save off timestamp and argument array
         echo -en $(date "+%FT%TZ") > "${statedir}/${called}/timestamp"
         printf "\"%s\" " "${@}" > "${statedir}/${called}/args"
-        echo ${called} > "${statedir}/called"
     '
 
     # Create the mock

--- a/share/emock.sh
+++ b/share/emock.sh
@@ -147,10 +147,10 @@ emock()
         if [[ -e "${statedir}/called" ]]; then
             called=$(cat "${statedir}/called")
             (( called++ ))
-        fi 
+        fi
         echo ${called} > "${statedir}/called"
- 
-       # Create directory to store files in for this invocation
+
+        # Create directory to store files in for this invocation
         mkdir -p "${statedir}/${called}"
 
         # Save off timestamp and argument array

--- a/tests/emock.etest
+++ b/tests/emock.etest
@@ -155,8 +155,8 @@ ETEST_emock_return_code()
     etestmsg "Calling mocked func"
     $(tryrc func)
     assert_eq 0 ${rc}
-    assert_eq 0 "$(emock_return_code "func" 0)"
-    assert_emock_return_code "func" 0 0
+    assert_eq 0 "$(emock_return_code "func" 1)"
+    assert_emock_return_code "func" 1 0
 
     etestmsg "Calling func_real"
     $(tryrc func_real)
@@ -178,7 +178,7 @@ ETEST_emock_stdout()
     $(tryrc --stdout=stdout func)
     assert_eq "mock stdout" "${stdout}"
     assert_eq "mock stdout" "$(emock_stdout "func")"
-    assert_emock_stdout "func" 0 "mock stdout"
+    assert_emock_stdout "func" 1 "mock stdout"
 
     etestmsg "Calling func_real"
     $(tryrc --stdout=stdout func_real)
@@ -192,20 +192,11 @@ ETEST_emock_stdout_repeat()
         echo "func stdout" >&1
     }
 
-    etestmsg "Mocking with stdout #0"
-    emock --stdout "mock stdout #0" "func"
-    assert_match "$(type func)" "func is a function"
-    $(tryrc --stdout=stdout func)
-    assert_eq "mock stdout #0" "${stdout}"
-    assert_eq "mock stdout #0" "$(emock_stdout "func")"
-    assert_eq "mock stdout #0" "$(emock_stdout "func" 0)"
-    assert_emock_stdout "func" 0 "mock stdout #0"
-
     etestmsg "Mocking with stdout #1"
     emock --stdout "mock stdout #1" "func"
+    assert_match "$(type func)" "func is a function"
     $(tryrc --stdout=stdout func)
     assert_eq "mock stdout #1" "${stdout}"
-    assert_eq 1 "$(emock_called func)"
     assert_eq "mock stdout #1" "$(emock_stdout "func")"
     assert_eq "mock stdout #1" "$(emock_stdout "func" 1)"
     assert_emock_stdout "func" 1 "mock stdout #1"
@@ -214,9 +205,18 @@ ETEST_emock_stdout_repeat()
     emock --stdout "mock stdout #2" "func"
     $(tryrc --stdout=stdout func)
     assert_eq "mock stdout #2" "${stdout}"
+    assert_eq 2 "$(emock_called func)"
     assert_eq "mock stdout #2" "$(emock_stdout "func")"
     assert_eq "mock stdout #2" "$(emock_stdout "func" 2)"
     assert_emock_stdout "func" 2 "mock stdout #2"
+
+    etestmsg "Mocking with stdout #3"
+    emock --stdout "mock stdout #3" "func"
+    $(tryrc --stdout=stdout func)
+    assert_eq "mock stdout #3" "${stdout}"
+    assert_eq "mock stdout #3" "$(emock_stdout "func")"
+    assert_eq "mock stdout #3" "$(emock_stdout "func" 3)"
+    assert_emock_stdout "func" 3 "mock stdout #3"
 
     etestmsg "Verifying older entries not erased"
     assert_eq "mock stdout #1" "$(emock_stdout "func" 1)"
@@ -242,7 +242,7 @@ ETEST_emock_stderr()
     assert_eq "mock stdout" "${stdout}"
     assert_eq "mock stderr" "${stderr}"
     assert_eq "mock stdout" "$(emock_stdout "func")"
-    assert_emock_stdout "func" 0 "mock stdout"
+    assert_emock_stdout "func" 1 "mock stdout"
 
     etestmsg "Calling func_real"
     $(tryrc --stdout=stdout --stderr=stderr func_real)
@@ -300,24 +300,26 @@ ETEST_emock_body()
 
     etestmsg "Calling with args=bar (should succeed)"
     $(tryrc func "bar")
+
     assert_eq 0 ${rc}
     etestmsg "Mocked function was called with:"
-    cat .emock-$$/func/0/args
-    assert_emock_called_with "func" 0 "bar"
+    cat .emock-$$/func/1/args
+    assert_emock_called_with "func" 1 "bar"
+ 
 
     etestmsg "Mocked function return_code:"
-    cat .emock-$$/func/0/return_code
-    assert_emock_return_code "func" 0 0
+    cat .emock-$$/func/1/return_code
+    assert_emock_return_code "func" 1 0
 
     etestmsg "Calling with args=foo (should fail)"
     $(tryrc func "foo")
     assert_eq 1 ${rc}
     etestmsg "Mocked function was called with:"
-    cat .emock-$$/func/1/args
-    emock_args "func" 1
-    assert_emock_called_with "func" 1 "foo"
+    cat .emock-$$/func/2/args
+    emock_args "func" 2
+    assert_emock_called_with "func" 2 "foo"
 
     etestmsg "Mocked function return_code:"
-    cat .emock-$$/func/1/return_code
-    assert_emock_return_code "func" 1 1
+    cat .emock-$$/func/2/return_code
+    assert_emock_return_code "func" 2 1
 }


### PR DESCRIPTION
This may or may not be desired behavior and just wanted to start a conversation. I was noticing when using the emock facility the call count starts at zero, which is a bit misleading.

For instance, I had a test that called a systemctl mock 4 times but yet:

```
[root@5961892ebeb2 systemctl]# pwd
/emock/systemctl
[root@5961892ebeb2 systemctl]# ls
0  1  2  3  called  mode
[root@5961892ebeb2 systemctl]# cat 0/args
"is-active" "--quiet" "slurmctld" 
[root@5961892ebeb2 systemctl]# cat 1/args
"stop" "slurmctld" 
[root@5961892ebeb2 systemctl]# cat 2/args
"is-active" "--quiet" "slurmd" 
[root@5961892ebeb2 systemctl]# cat 3/args
"stop" "slurmd" 
[root@5961892ebeb2 systemctl]#
```