### PR TITLE
Wow, this was a real mess. Thanks Ray for finding it!

### DIFF
--- a/share/emock.sh
+++ b/share/emock.sh
@@ -103,7 +103,7 @@ emock()
         ":statedir=${PWD}/.emock-$$         | This directory is used to track state about mocked binaries. This will
                                               hold metadata information such as the number of times the mock was called
                                               as well as the return code, stdout, and stderr for each invocation."     \
-        "+delete      d                     | Delete existing mock state inside statedir from prior mock invocations." \
+        "+reset       r                     | Reset existing mock state inside statedir from prior mock invocations." \
         "name                               | Name of the binary to mock (e.g. dmidecode or /usr/sbin/dmidecode). This
                                               must match the calling convention at the call site."                     \
         "?body                              | This allows fine-grained control over the body of the mocked function that
@@ -115,7 +115,7 @@ emock()
 
     # Prepare statedir
     statedir+="/$(basename "${name}")"
-    if [[ "${delete}" -eq 1 ]]; then
+    if [[ "${reset}" -eq 1 ]]; then
         efreshdir "${statedir}"
     else
         mkdir -p "${statedir}"

--- a/share/emock.sh
+++ b/share/emock.sh
@@ -121,6 +121,11 @@ emock()
         mkdir -p "${statedir}"
     fi
 
+    # Create called file if it doesnt' exist.
+    if [[ ! -e "${statedir}/called" ]]; then
+        echo "0" > "${statedir}/called"
+    fi
+
     # Prepare the base of the mock function body. We have to put a proper interpreter if we're in filesystem mode
     # and otherwise we need to prepare the function by removing some of our ebash protections.
     local base_body="" return_statement=""
@@ -142,26 +147,23 @@ emock()
         # Create state directory
         statedir="'${statedir}'"
 
-        # Update call count
-        called=0
-        if [[ -e "${statedir}/called" ]]; then
-            called=$(cat "${statedir}/called")
-            (( called++ ))
-        fi
-        echo ${called} > "${statedir}/called"
+        # Get current call count for all our state files. Then update called count inside the file.
+        # Do not modify our local variable as that would cause us to write out to the wrong state files.
+        called=$(cat "${statedir}/called")
+        echo "$(( called + 1 ))" > "${statedir}/called"
 
         # Create directory to store files in for this invocation
         mkdir -p "${statedir}/${called}"
 
         # Save off timestamp and argument array
         echo -en $(date "+%FT%TZ") > "${statedir}/${called}/timestamp"
-        printf "\"%s\" " "${@}" > "${statedir}/${called}/args"
+        printf "%s\n" "${@}" > "${statedir}/${called}/args"
     '
 
     # Create the mock
     if [[ -z "${body}" ]]; then
         body='
-        {
+        (
             '${base_body}'
 
             # Save off stdout and stderr
@@ -175,10 +177,10 @@ emock()
             # Return / Exit
             echo -n '${return_code}' > "${statedir}/${called}/return_code"
             '${return_statement}' '${return_code}'
-        }'
+        )'
     else
         body='
-        {
+        (
             '${base_body}'
             ( '${body}' )
 
@@ -186,7 +188,7 @@ emock()
             local return_code=$?
             echo -n ${return_code} > "${statedir}/${called}/return_code"
             '${return_statement}' ${return_code}
-        }'
+        )'
     fi
 
     # Now, if we're in filesystem mode, creat the mock on-disk. Otherwise create in-memory mocks.
@@ -301,6 +303,47 @@ emock_called()
     echo -n "${called}"
 }
 
+opt_usage emock_indexes <<'END'
+`emock_indexes` makes it easier to get the call indexes for the mock invocations. Think of this as the array
+indexes where the first call will have a call index of `0`, the second call will have a call index of `1`, etc. This is
+different than `emock_called` which a 1-based count. This is a 0-based list of call invocation numbers.
+
+So if this has never been called, then `emock_indexes` will echo an empty string. If it has been called 3 times then
+this will echo `0 1 2`. These corresponding to the directories: `${statedir}/0 ${statedir}/1 ${statedir}/2`.
+END
+emock_indexes()
+{
+    $(opt_parse \
+        ":statedir=${PWD}/.emock-$$         | This directory is used to track state about mocked binaries. This will
+                                              hold metadata information such as the number of times the mock was called
+                                              as well as the exit code, stdout, and stderr for each invocation."       \
+        "+last                              | Display the LAST index only rather than all indexes."                    \
+        "name                               | Name of the binary to mock (e.g. dmidecode or /usr/sbin/dmidecode)."     \
+    )
+
+    local path base indexes=()
+    statedir+="/$(basename "${name}")"
+    for path in "${statedir}"/*; do
+        base=$(basename "${path}")
+        if [[ -d "${path}" ]] && is_int "${base}"; then
+            indexes+=( "${base}" )
+        fi
+    done
+
+    # If there was nothing found just return immediately.
+    if array_empty indexes; then
+        return 0
+    fi
+
+    array_sort --version indexes
+
+    if [[ ${last} -eq 0 ]]; then
+        echo "${indexes[@]}"
+    else
+        echo "${indexes[-1]}"
+    fi
+}
+
 opt_usage emock_stdout <<'END'
 `emock_stdout` is a utility function to make it easier to get the standard output from a particular invocation of a
 mocked function. This is stored on-disk and is easy to manually retrieve, but this function should always be used to
@@ -318,7 +361,7 @@ emock_stdout()
     )
 
     if [[ -z "${num}" ]]; then
-        num=$(opt_forward emock_called statedir -- ${name})
+        num=$(opt_forward emock_indexes statedir -- --last ${name})
     fi
 
     statedir+="/$(basename "${name}")"
@@ -347,7 +390,7 @@ emock_stderr()
     )
 
     if [[ -z "${num}" ]]; then
-        num=$(opt_forward emock_called statedir -- ${name})
+        num=$(opt_forward emock_indexes statedir -- --last ${name})
     fi
 
     statedir+="/$(basename "${name}")"
@@ -364,11 +407,11 @@ opt_usage emock_args <<'END'
 function. This is stored on-disk and is easy to manually retrieve, but this function should always be used to provide a
 clean abstraction. If the call number is not provided, this will default to the most recent invocation's argument array.
 
-Inside the statedir, the argument array is stored with each argument fully quoted so that whitespace encapsulated
-arguments preserve whitespace. To convert this back into an array, the best thing to do is to use array_init:
+Inside the statedir, the argument array is stored as a newline separated file so that whitespace is preserved.
+To convert this back into an array, the best thing to do is to use array_init_nl:
 
 ```shell
-array_init args "$(emock_args func)"
+array_init_nl args "$(emock_args func)"
 ```
 
 Alternatively, the helper `assert_emock_called_with` is an extremely useful way to validate the arguments passed
@@ -385,12 +428,11 @@ emock_args()
     )
 
     if [[ -z "${num}" ]]; then
-        num=$(opt_forward emock_called statedir -- ${name})
+        num=$(opt_forward emock_indexes statedir -- --last ${name})
     fi
 
     statedir+="/$(basename "${name}")"
     if [[ -e "${statedir}/${num}/args" ]]; then
-        cat "${statedir}/${num}/args" | edebug
         cat "${statedir}/${num}/args"
     fi
 }
@@ -412,7 +454,7 @@ emock_return_code()
     )
 
     if [[ -z "${num}" ]]; then
-        num=$(opt_forward emock_called statedir -- ${name})
+        num=$(opt_forward emock_indexes statedir -- --last ${name})
     fi
 
     statedir+="/$(basename "${name}")"
@@ -559,10 +601,16 @@ assert_emock_called_with()
                                               as well as the exit code, stdout, and stderr for each invocation."       \
         "name                               | Name of the binary to mock (e.g. dmidecode or /usr/sbin/dmidecode)."     \
         "num                                | The call number to look at the arguments for."                           \
-        "@args                              | Argument array we expect the mock function to have been called with."    \
+        "@expect                            | Argument array we expect the mock function to have been called with."    \
     )
 
     local actual=""
-    array_init actual "$(opt_forward emock_args statedir -- ${name} ${num})"
-    diff --unified <(printf "\"%s\" " "${args[@]}") <(echo -n "${actual[@]} ")
+    array_init_nl actual "$(opt_forward emock_args statedir -- ${name} ${num})"
+
+    if edebug_enabled; then
+        edebug "EXPECT: $(lval expect)"
+        edebug "ACTUAL: $(lval actual)"
+    fi
+
+    diff <(printf "%s\n" "${expect[@]}") <(printf "%s\n" "${actual[@]}")
 }

--- a/tests/emock.etest
+++ b/tests/emock.etest
@@ -16,8 +16,9 @@
 # (1) Exists on all target systems we run tests on
 # (2) We do not need to use inside this test or in any functions we call. Since we're mocking it out it won't be
 #     callable.
-test_binary="perlbug"
+test_binary="reset"
 test_binary_path="$(which ${test_binary})"
+test_binary_flag="-V"
 
 dump_state()
 {
@@ -82,7 +83,7 @@ ETEST_emock_and_filesystem_multiple()
     assert_eq "file" "$(type -t ${test_binary_path})"
     assert_eq "file" "$(type -t ${test_binary_path}_real)"
     assert_eq "filesystem" "$(emock_mode "${test_binary}")"
-    file "${test_binary_path}" | grep -Pq "(ASCII text|bash script|Bourne-Again shell script)"
+    file -L "${test_binary_path}" | grep -Pq "(ASCII text|bash script|Bourne-Again shell script)"
 
     etestmsg "Mocking ${test_binary} with --filesystem and --return 1"
     emock --filesystem --return 1 "${test_binary_path}"
@@ -94,7 +95,7 @@ ETEST_emock_and_filesystem_multiple()
 
     etestmsg "Unmocking"
     eunmock "${test_binary_path}"
-    file "${test_binary_path}" | grep -Pq "ELF"
+    file -L "${test_binary_path}" | grep -Pq "ELF"
 }
 
 ETEST_emock_called()
@@ -173,7 +174,7 @@ ETEST_emock_called_filesystem()
     assert_eq 1 "$(cat .emock-$$/${test_binary}/called)"
     assert_eq 1 "$(emock_called ${test_binary_path})"
     assert_emock_called "${test_binary_path}" 1
-    assert_eq "0" "$(emock_indexes --last "func")"
+    assert_eq "0" "$(emock_indexes --last "${test_binary_path}")"
     assert_directory_contents .emock-$$/${test_binary} \
         called        \
         mode          \
@@ -249,7 +250,7 @@ ETEST_emock_real()
 
     # Verify we can _use_ the real function
     etestmsg "Verifying we can call ${test_binary}_real wrapper"
-    ${test_binary}_real .
+    ${test_binary}_real ${test_binary_flag}
 }
 
 ETEST_emock_return_code()

--- a/tests/emock.etest
+++ b/tests/emock.etest
@@ -12,13 +12,8 @@
 #
 #-----------------------------------------------------------------------------------------------------------------------
 
-if os darwin; then
-    test_binary="gfind"
-    test_binary_path="/usr/local/bin/gfind"
-else
-    test_binary="find"
-    test_binary_path="$(which find)"
-fi
+test_binary="yes"
+test_binary_path="$(which ${test_binary})"
 
 dump_state()
 {
@@ -109,13 +104,14 @@ ETEST_emock_called()
     assert_eq 0 "$(emock_called func)"
     assert_emock_called "func" 0
 
-    #### CALL #0 ####
-    etestmsg "Calling mocked func (0)"
+    ## CALL 1 (index 0) ##
+    etestmsg "Calling mock#1 index=0"
     func
     dump_state
     assert_eq 1 "$(cat .emock-$$/func/called)"
     assert_eq 1 "$(emock_called func)"
     assert_emock_called "func" 1
+    assert_eq "0" "$(emock_indexes "func")"
     assert_directory_contents .emock-$$/func \
         called        \
         mode          \
@@ -126,14 +122,16 @@ ETEST_emock_called()
         0/timestamp   \
         0/args
 
-    #### CALL #1 ####
+    ## CALL 2 (index 1) ##
     echo
-    etestmsg "Calling mocked func (1)"
+    etestmsg "Calling mock#1 index=1"
     func
     dump_state
     assert_eq 2 "$(cat .emock-$$/func/called)"
     assert_eq 2 "$(emock_called func)"
     assert_emock_called "func" 2
+    assert_eq "0 1" "$(emock_indexes "func")"
+    assert_eq "1" "$(emock_indexes --last "func")"
     assert_directory_contents .emock-$$/func \
         called        \
         mode          \
@@ -159,20 +157,19 @@ ETEST_emock_called_filesystem()
     etestmsg "Mocking ${test_binary} with full path and --filesystem"
     emock --filesystem "${test_binary_path}"
     trap_add "eunmock ${test_binary_path}"
-
     assert_eq "filesystem" "$(emock_mode "${test_binary}")"
     assert_exists "${test_binary_path}_real"
-
     assert_eq 0 "$(emock_called ${test_binary_path})"
     assert_emock_called "${test_binary_path}" 0
 
-    ## CALL #0 ##
-    etestmsg "Calling mock (#0)"
+    ## CALL 1 (index 0) ##
+    etestmsg "Calling mock#1 index=0"
     ${test_binary_path}
     dump_state
     assert_eq 1 "$(cat .emock-$$/${test_binary}/called)"
     assert_eq 1 "$(emock_called ${test_binary_path})"
     assert_emock_called "${test_binary_path}" 1
+    assert_eq "0" "$(emock_indexes --last "func")"
     assert_directory_contents .emock-$$/${test_binary} \
         called        \
         mode          \
@@ -183,9 +180,9 @@ ETEST_emock_called_filesystem()
         0/timestamp   \
         0/args
 
-    ## CALL #1 ##
+    ## CALL 2 (index 1) ##
     echo
-    etestmsg "Calling mock (#1)"
+    etestmsg "Calling mock#2 index=1"
     ${test_binary_path}
     dump_state
     assert_eq 2 "$(cat .emock-$$/${test_binary}/called)"
@@ -218,16 +215,16 @@ ETEST_emock_indexes()
     assert_emock_called "func" 0
     assert_empty "$(emock_indexes "func")"
 
-    #### CALL #0 ####
-    etestmsg "Calling mocked func (0)"
+    ## CALL 1 (index 0) ##
+    etestmsg "Calling mock#1 index=0"
     func
     dump_state
     assert_emock_called "func" 1
     assert_eq "0" "$(emock_indexes "func")"
 
-    #### CALL #1 ####
+    ## CALL 2 (index 1) ##
     echo
-    etestmsg "Calling mocked func (1)"
+    etestmsg "Calling mock#2 index=1"
     func
     dump_state
     assert_emock_called "func" 2
@@ -300,33 +297,35 @@ ETEST_emock_stdout_repeat()
         echo "func stdout" >&1
     }
 
-    ## CALL #1 (index 0) ##
-    etestmsg "Mocking with stdout #0"
+    ## CALL 1 (index 0) ##
+    etestmsg "Calling mock#1 index=0 (with stdout #0)"
     emock --stdout "mock stdout #0" "func"
     $(tryrc --stdout=stdout func)
     assert_eq 1 "$(emock_called func)"
-    assert_eq 0 "$(emock_indexes --last func)"
+    assert_eq 0 "$(emock_indexes func)"
     assert_eq "mock stdout #0" "${stdout}"
     assert_eq "mock stdout #0" "$(emock_stdout "func")"
     assert_eq "mock stdout #0" "$(emock_stdout "func" 0)"
     assert_emock_stdout "func" 0 "mock stdout #0"
 
-    ## CALL #2 (index 1) ##
-    etestmsg "Mocking with stdout #1"
+    ## CALL 2 (index 1) ##
+    etestmsg "Calling mock#2 index=1 (with stdout #1)"
     emock --stdout "mock stdout #1" "func"
     $(tryrc --stdout=stdout func)
     assert_eq 2 "$(emock_called func)"
-    assert_eq 1 "$(emock_indexes --last func)"
+    assert_eq "0 1" "$(emock_indexes func)"
+    assert_eq "1" "$(emock_indexes --last func)"
     assert_eq "mock stdout #1" "${stdout}"
     assert_eq "mock stdout #1" "$(emock_stdout "func")"
     assert_eq "mock stdout #1" "$(emock_stdout "func" 1)"
     assert_emock_stdout "func" 1 "mock stdout #1"
 
-    ## CALL #3 (index 2) ##
-    etestmsg "Mocking with stdout #2"
+    ## CALL 3 (index 2) ##
+    etestmsg "Calling mock#3 index=2 (with stdout #2)"
     emock --stdout "mock stdout #2" "func"
     $(tryrc --stdout=stdout func)
     assert_eq 3 "$(emock_called func)"
+    assert_eq "0 1 2" "$(emock_indexes func)"
     assert_eq 2 "$(emock_indexes --last func)"
     assert_eq "mock stdout #2" "${stdout}"
     assert_eq "mock stdout #2" "$(emock_stdout "func")"
@@ -372,7 +371,7 @@ ETEST_emock_args()
     etestmsg "Mocking func"
     emock "func"
 
-    ## CALL #0 ##
+    ## CALL 1 (index 0) ##
     etestmsg "Calling func with arguments"
     func "1" "2" "3" "dogs and cats" "Anarchy"
     dump_state

--- a/tests/emock.etest
+++ b/tests/emock.etest
@@ -12,7 +12,11 @@
 #
 #-----------------------------------------------------------------------------------------------------------------------
 
-test_binary="yes"
+# Binary we can mock out. This should ideally be one that:
+# (1) Exists on all target systems we run tests on
+# (2) We do not need to use inside this test or in any functions we call. Since we're mocking it out it won't be
+#     callable.
+test_binary="perlbug"
 test_binary_path="$(which ${test_binary})"
 
 dump_state()

--- a/tests/emock.etest
+++ b/tests/emock.etest
@@ -6,6 +6,12 @@
 # as published by the Apache Software Foundation, either version 2 of the License, or (at your option) any later
 # version.
 
+#-----------------------------------------------------------------------------------------------------------------------
+#
+# Setup
+#
+#-----------------------------------------------------------------------------------------------------------------------
+
 if os darwin; then
     test_binary="gfind"
     test_binary_path="/usr/local/bin/gfind"
@@ -14,11 +20,31 @@ else
     test_binary_path="$(which find)"
 fi
 
+dump_state()
+{
+    local fname="" contents=""
+    for fname in $(find .emock-$$ -type f); do
+        contents=""
+        if [[ $(basename "${fname}") == "args" ]]; then
+            array_init_nl contents "$(cat ${fname})"
+        else
+            contents="$(cat "${fname}")"
+        fi
+
+        etestmsg "$(lval fname contents)"
+    done
+}
+
+#-----------------------------------------------------------------------------------------------------------------------
+#
+# Tests
+#
+#-----------------------------------------------------------------------------------------------------------------------
 ETEST_emock()
 {
     etestmsg "Mocking ${test_binary}"
     emock "${test_binary}"
-    assert_match "$(type ${test_binary})" "${test_binary} is a function"
+    assert_eq "function" "$(type -t ${test_binary})"
     eunmock "${test_binary}"
     assert_match "$(hash -r; type ${test_binary})" "${test_binary} is ${test_binary_path}"
 }
@@ -27,7 +53,7 @@ ETEST_emock_and_path()
 {
     etestmsg "Mocking ${test_binary} with full path"
     emock "${test_binary_path}"
-    assert_match "$(type ${test_binary_path})" "${test_binary_path} is a function"
+    assert_eq "function" "$(type -t ${test_binary_path})"
     eunmock "${test_binary_path}"
     assert_match "$(hash -r; type ${test_binary_path})" "${test_binary_path} is ${test_binary_path}"
 }
@@ -74,26 +100,55 @@ ETEST_emock_and_filesystem_multiple()
 
 ETEST_emock_called()
 {
-    func()
-    {
-        true
-    }
+    func() { true; }
 
     etestmsg "Mocking func"
     emock "func"
-    assert_match "$(type func)" "func is a function"
+    dump_state
+    assert_eq 0 "$(cat .emock-$$/func/called)"
     assert_eq 0 "$(emock_called func)"
     assert_emock_called "func" 0
 
-    etestmsg "Calling mocked func"
+    #### CALL #0 ####
+    etestmsg "Calling mocked func (0)"
     func
+    dump_state
+    assert_eq 1 "$(cat .emock-$$/func/called)"
     assert_eq 1 "$(emock_called func)"
     assert_emock_called "func" 1
+    assert_directory_contents .emock-$$/func \
+        called        \
+        mode          \
+        0             \
+        0/return_code \
+        0/stdout      \
+        0/stderr      \
+        0/timestamp   \
+        0/args
 
-    etestmsg "Calling mocked func"
+    #### CALL #1 ####
+    echo
+    etestmsg "Calling mocked func (1)"
     func
+    dump_state
+    assert_eq 2 "$(cat .emock-$$/func/called)"
     assert_eq 2 "$(emock_called func)"
     assert_emock_called "func" 2
+    assert_directory_contents .emock-$$/func \
+        called        \
+        mode          \
+        0             \
+        0/return_code \
+        0/stdout      \
+        0/stderr      \
+        0/timestamp   \
+        0/args        \
+        1             \
+        1/return_code \
+        1/stdout      \
+        1/stderr      \
+        1/timestamp   \
+        1/args
 }
 
 ETEST_emock_called_filesystem()
@@ -105,25 +160,80 @@ ETEST_emock_called_filesystem()
     emock --filesystem "${test_binary_path}"
     trap_add "eunmock ${test_binary_path}"
 
-    assert_eq "file" "$(type -t ${test_binary_path})"
-    assert_eq "file" "$(type -t ${test_binary_path}_real)"
     assert_eq "filesystem" "$(emock_mode "${test_binary}")"
     assert_exists "${test_binary_path}_real"
 
     assert_eq 0 "$(emock_called ${test_binary_path})"
     assert_emock_called "${test_binary_path}" 0
 
-    etestmsg "Calling mock"
+    ## CALL #0 ##
+    etestmsg "Calling mock (#0)"
     ${test_binary_path}
-    find .emock-$$
-    cat .emock-$$/${test_binary}/called
+    dump_state
+    assert_eq 1 "$(cat .emock-$$/${test_binary}/called)"
     assert_eq 1 "$(emock_called ${test_binary_path})"
     assert_emock_called "${test_binary_path}" 1
+    assert_directory_contents .emock-$$/${test_binary} \
+        called        \
+        mode          \
+        0             \
+        0/return_code \
+        0/stdout      \
+        0/stderr      \
+        0/timestamp   \
+        0/args
 
-    etestmsg "Calling mocked"
+    ## CALL #1 ##
+    echo
+    etestmsg "Calling mock (#1)"
     ${test_binary_path}
+    dump_state
+    assert_eq 2 "$(cat .emock-$$/${test_binary}/called)"
     assert_eq 2 "$(emock_called ${test_binary_path})"
     assert_emock_called "${test_binary_path}" 2
+    assert_directory_contents .emock-$$/${test_binary} \
+        called        \
+        mode          \
+        0             \
+        0/return_code \
+        0/stdout      \
+        0/stderr      \
+        0/timestamp   \
+        0/args        \
+        1             \
+        1/return_code \
+        1/stdout      \
+        1/stderr      \
+        1/timestamp   \
+        1/args
+}
+
+ETEST_emock_indexes()
+{
+    func() { true; }
+
+    etestmsg "Mocking func"
+    emock "func"
+    dump_state
+    assert_emock_called "func" 0
+    assert_empty "$(emock_indexes "func")"
+
+    #### CALL #0 ####
+    etestmsg "Calling mocked func (0)"
+    func
+    dump_state
+    assert_emock_called "func" 1
+    assert_eq "0" "$(emock_indexes "func")"
+
+    #### CALL #1 ####
+    echo
+    etestmsg "Calling mocked func (1)"
+    func
+    dump_state
+    assert_emock_called "func" 2
+    assert_eq "0 1" "$(emock_indexes "func")"
+    assert_eq "1"   "$(emock_indexes --last "func")"
+
 }
 
 ETEST_emock_real()
@@ -133,8 +243,8 @@ ETEST_emock_real()
 
     etestmsg "Mocking ${test_binary}"
     emock "${test_binary}"
-    assert_match "$(type ${test_binary})"      "${test_binary} is a function"
-    assert_match "$(type ${test_binary}_real)" "${test_binary}_real is a function"
+    assert_eq "function" "$(type -t ${test_binary})"
+    assert_eq "function" "$(type -t ${test_binary}_real)"
 
     # Verify we can _use_ the real function
     etestmsg "Verifying we can call ${test_binary}_real wrapper"
@@ -150,7 +260,6 @@ ETEST_emock_return_code()
 
     etestmsg "Mocking func"
     emock --return-code 0 "func"
-    assert_match "$(type func)" "func is a function"
 
     etestmsg "Calling mocked func"
     $(tryrc func)
@@ -172,7 +281,6 @@ ETEST_emock_stdout()
 
     etestmsg "Mocking with stdout"
     emock --stdout "mock stdout" "func"
-    assert_match "$(type func)" "func is a function"
 
     etestmsg "Calling mocked func"
     $(tryrc --stdout=stdout func)
@@ -192,27 +300,34 @@ ETEST_emock_stdout_repeat()
         echo "func stdout" >&1
     }
 
+    ## CALL #1 (index 0) ##
     etestmsg "Mocking with stdout #0"
     emock --stdout "mock stdout #0" "func"
-    assert_match "$(type func)" "func is a function"
     $(tryrc --stdout=stdout func)
+    assert_eq 1 "$(emock_called func)"
+    assert_eq 0 "$(emock_indexes --last func)"
     assert_eq "mock stdout #0" "${stdout}"
     assert_eq "mock stdout #0" "$(emock_stdout "func")"
     assert_eq "mock stdout #0" "$(emock_stdout "func" 0)"
     assert_emock_stdout "func" 0 "mock stdout #0"
 
+    ## CALL #2 (index 1) ##
     etestmsg "Mocking with stdout #1"
     emock --stdout "mock stdout #1" "func"
     $(tryrc --stdout=stdout func)
+    assert_eq 2 "$(emock_called func)"
+    assert_eq 1 "$(emock_indexes --last func)"
     assert_eq "mock stdout #1" "${stdout}"
-    assert_eq 1 "$(emock_called func)"
     assert_eq "mock stdout #1" "$(emock_stdout "func")"
     assert_eq "mock stdout #1" "$(emock_stdout "func" 1)"
     assert_emock_stdout "func" 1 "mock stdout #1"
 
+    ## CALL #3 (index 2) ##
     etestmsg "Mocking with stdout #2"
     emock --stdout "mock stdout #2" "func"
     $(tryrc --stdout=stdout func)
+    assert_eq 3 "$(emock_called func)"
+    assert_eq 2 "$(emock_indexes --last func)"
     assert_eq "mock stdout #2" "${stdout}"
     assert_eq "mock stdout #2" "$(emock_stdout "func")"
     assert_eq "mock stdout #2" "$(emock_stdout "func" 2)"
@@ -234,7 +349,6 @@ ETEST_emock_stderr()
 
     etestmsg "Mocking with stdout and stderr"
     emock --return-code 0 --stdout "mock stdout" --stderr "mock stderr" "func"
-    assert_match "$(type func)" "func is a function"
 
     etestmsg "Calling mocked func"
     $(tryrc --stdout=stdout --stderr=stderr func)
@@ -257,14 +371,13 @@ ETEST_emock_args()
 
     etestmsg "Mocking func"
     emock "func"
-    assert_match "$(type func)" "func is a function"
 
+    ## CALL #0 ##
     etestmsg "Calling func with arguments"
     func "1" "2" "3" "dogs and cats" "Anarchy"
-    cat ".emock-$$/func/0/args"
-    echo
+    dump_state
     local args
-    args=( $(emock_args func) )
+    array_init_nl args "$(emock_args func)"
 
     etestmsg "Captured func $(lval args)"
     assert_eq 5 $(array_size args)
@@ -277,7 +390,7 @@ ETEST_emock_args()
     assert_emock_called_with "func" 0 \
         "1" "2" "3" "dogs and cats" "Anarchy"
 
-    expected=( "1" "2" "3" "docs and cats" "Anarchy" )
+    expected=( "1" "2" "3" "dogs and cats" "Anarchy" )
     assert_emock_called_with "func" 0 "${expected[@]}"
 }
 
@@ -296,10 +409,9 @@ ETEST_emock_body()
         fi
     }'
 
-    assert_match "$(type func)" "func is a function"
-
     etestmsg "Calling with args=bar (should succeed)"
     $(tryrc func "bar")
+    dump_state
     assert_eq 0 ${rc}
     etestmsg "Mocked function was called with:"
     cat .emock-$$/func/0/args
@@ -311,6 +423,7 @@ ETEST_emock_body()
 
     etestmsg "Calling with args=foo (should fail)"
     $(tryrc func "foo")
+    dump_state
     assert_eq 1 ${rc}
     etestmsg "Mocked function was called with:"
     cat .emock-$$/func/1/args


### PR DESCRIPTION
@thecodenomad found so many bugs! Love you Ray.

As you noted, the `called` file wasn't reflecting the right call count. There were many bugs I found while doing some TDD and really hardening the hell out of this. The most important are:

1. Holy hell, I disabled fatal error handling inside the mock, but didn't do it in a subshell, so this affected entire etest environment. Which was making failures in all the tests after this. WOW. NOOB.

2. Obviously, we were incrementing `called` file incorrectly. On the first call we would write out `0` into called instead of `1`. The tests were not detecting this because of (1).

3. All the code that looked up the last called value to get the number to use if not explicitly passed in were also off by one. Gah. I added a new function `emock_indexes` which also takes a `--last` to make this way more explicit.

4. Rewrote a TON of the tests to really ensure I didn't screw this up again.