### PR TITLE
Shellcheck

### DIFF
--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -61,7 +61,7 @@ jobs:
         run: bin/bashlint --errors
 
       - name: Self Test
-        run: bin/selftest
+        run: bin/eretry bin/selftest
 
       - name: Test
         run: bin/etest --work-dir .work/output --failures 1
@@ -96,7 +96,7 @@ jobs:
         run: bin/bashlint --errors
 
       - name: Self Test
-        run: bin/selftest
+        run: bin/eretry bin/selftest
 
       - name: Test
         run: bin/etest --work-dir .work/output --failures 1

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -61,7 +61,7 @@ jobs:
         run: bin/bashlint --errors
 
       - name: Self Test
-        run: bin/eretry bin/selftest
+        run: bin/selftest
 
       - name: Test
         run: bin/etest --work-dir .work/output --failures 1
@@ -96,7 +96,7 @@ jobs:
         run: bin/bashlint --errors
 
       - name: Self Test
-        run: bin/eretry bin/selftest
+        run: bin/selftest
 
       - name: Test
         run: bin/etest --work-dir .work/output --failures 1

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -58,7 +58,7 @@ jobs:
         run: install/all
 
       - name: Lint
-        run: bin/bashlint
+        run: bin/bashlint --errors
 
       - name: Self Test
         run: bin/eretry bin/selftest
@@ -93,7 +93,7 @@ jobs:
         run: install/all
 
       - name: Lint
-        run: bin/bashlint
+        run: bin/bashlint --errors
 
       - name: Self Test
         run: bin/eretry bin/selftest

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ clobber: clean
 
 .PHONY: lint bashlint
 lint bashlint:
-	bin/bashlint --break=${BREAK}
+	bin/bashlint --break=${BREAK} --internal --errors
 
 .PHONY: selftest
 selftest:

--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,9 @@ clobber: clean
 	sudo bin/ebash git clean -fd
 	sudo bin/ebash git clean -fX
 
-.PHONY: lint
-lint:
-	bin/bashlint
+.PHONY: lint bashlint
+lint bashlint:
+	bin/bashlint --break=${BREAK}
 
 .PHONY: selftest
 selftest:

--- a/bin/bashlint
+++ b/bin/bashlint
@@ -12,14 +12,24 @@
 source ${EBASH}/ebash.sh || { echo "Unable to source ${EBASH}/ebash.sh" ; exit 1 ; }
 
 opt_usage main <<'END'
-Analyze all the requested bash scripts in the specified directories and pass them through bash -n mode which asks bash
-to make sure the syntax looks okay without actually running anything. Additionally, perform several additional
-strictness checks that we have found to be sources of really subtle problems. Also checks some stylistic issues for
-consistent coding.
+Analyze all the requested bash scripts in the specified directories and perform various Linting operations on them. There
+are various internal checks performed by bashlint including bash syntax errors, using removed ebash code, ambiguous
+return statements, and combined variable declaration and assignment errors.
+
+Additionally, bashlint can utilize the fantastic external tool shellcheck to look for far more difficult to detect
+linting errors. By default these are all disabled. You can opt-in for which checks you want to perform with the various
+shellcheck-* option flags.
 END
 $(opt_parse \
-    "+break b | Break on first failure."          \
-    "+quiet q | Make bashlint produce no output." \
+    "+break b                      | Break on first failure."                                                          \
+    "+quiet q                      | Make bashlint produce no output."                                                 \
+    "+internal i=1                 | Run all ebash internal checks. This includes checking for bash syntax errors,
+                                     non-versioned ebash, deprecated ebash code, ambiguous return statements, combined
+                                     local variable declaration and assignment with a subshell result, etc."           \
+    "+shellcheck_errors errors     | Run Shellcheck looking for severity=error."                                       \
+    "+shellcheck_warnings warnings | Run Shellcheck looking for severity=warning and above."                           \
+    "+shellcheck_info info         | Run Shellcheck looking for severity=warning and above."                           \
+    "+shellcheck_style style       | Run Shellcheck looking for severity=warning and above."                           \
 )
 
 if [[ ${quiet} -eq 1 ]]; then
@@ -27,20 +37,20 @@ if [[ ${quiet} -eq 1 ]]; then
 fi
 
 # Paths to recursively parse
-PATHS=( ${@:-.} )
+paths=( ${@:-.} )
 
 # Helper function to display a failure and increment our failure count
-RC=0
-FAILURES=()
+rc=0
+failures=()
 fail()
 {
     emsg "${COLOR_ERROR}" "   -" "ERROR" "$@"
     eend 1
-    RC=1
+    rc=1
 }
 
-ebanner "Validating bash scripts" PATHS
-for fname in $(grep -lr '^#!/.*bash' ${PATHS[@]} | grep -v '.hg'); do
+ebanner "Validating bash scripts" paths opts=$(opt_log)
+for fname in $(grep -lr '^#!/.*bash' "${paths[@]}" | grep -v '.hg' | sort); do
 
     # If this isn't a bash script skip it
     file ${fname} | grep -Pq "(bash script|Bourne-Again shell script)" || continue
@@ -55,63 +65,87 @@ for fname in $(grep -lr '^#!/.*bash' ${PATHS[@]} | grep -v '.hg'); do
     echo -n "${einfo_message}" >&2
     bash -n ${fname}
 
-    # Read file into variable so we can do a little preprocessing on it before passing it into the various grep commands
-    # below to strip out particular patterns which would otherwise cause false positives.
-    CONTENTS=$(cat ${fname}              \
-        | grep -vP '^\s*#'               \
-        | grep -vP '#\s*BASHLINT_IGNORE' \
-        | grep -vP '^\s*function \w+'    \
-        | grep -vP '^\s*\w+\s*\(\)\s*$')
+    #---- INTERNAL ----#
+    if [[ "${internal}" -eq 1 ]]; then
 
-    # Initial error state
-    RC=0
+        # Read file into variable so we can do a little preprocessing on it before passing it into the various grep commands
+        # below to strip out particular patterns which would otherwise cause false positives.
+        CONTENTS=$(cat ${fname}              \
+            | grep -vP '^\s*#'               \
+            | grep -vP '#\s*BASHLINT_IGNORE' \
+            | grep -vP '^\s*function \w+'    \
+            | grep -vP '^\s*\w+\s*\(\)\s*$')
 
-    # Ensure none of the scripts are using non-versioned /usr/local/share/ebash
-    echo "${CONTENTS}" | egrep "(:|)/usr/local/share/ebash(:|/|\"|$)" \
-        && fail "Non-versioned ebash"
+        # Initial error state
+        rc=0
 
-    # Ensure not using removed $(esource ...)
-    echo "${CONTENTS}" | egrep '\s*\$\(esource ' \
-        && fail "Using removed esource function"
+        # Ensure none of the scripts are using non-versioned /usr/local/share/ebash
+        echo "${CONTENTS}" | egrep "(:|)/usr/local/share/ebash(:|/|\"|$)" \
+            && fail "Non-versioned ebash"
 
-    # Ensure not using removed argument parsing functions
-    echo "${CONTENTS}" | egrep '(declare_globals|declare_exports|declare_args|declare_opts)' \
-        && fail "Using removed declare_globals|declare_exports functions"
+        # Ensure not using removed $(esource ...)
+        echo "${CONTENTS}" | egrep '\s*\$\(esource ' \
+            && fail "Using removed esource function"
 
-    # Don't allow using removed legacy IFS ebash functions
-    echo "${CONTENTS}" | egrep '(ifs_save|ifs_restore|ifs_nl|ifs_space|ifs_set)' \
-        && fail "Using non-existent deprecated ifs_* functions"
+        # Ensure not using removed argument parsing functions
+        echo "${CONTENTS}" | egrep '(declare_globals|declare_exports|declare_args|declare_opts)' \
+            && fail "Using removed declare_globals|declare_exports functions"
 
-    # Ensure we don't have any sloppy 'return' statements which don't specify what return code to use. Because this
-    # usually returns the prior return code which is generally not what is intended and causes 'set -e' problems.
-    echo "${CONTENTS}" | egrep '^[^#]*return(\s*;|$)' \
-        && fail "Ambiguous return statements"
+        # Don't allow using removed legacy IFS ebash functions
+        echo "${CONTENTS}" | egrep '(ifs_save|ifs_restore|ifs_nl|ifs_space|ifs_set)' \
+            && fail "Using non-existent deprecated ifs_* functions"
 
-    echo "${CONTENTS}" | grep -P 'ekill.*-(SIG|TERM|KILL|INT|[0-9])' \
-        && fail "Ekill or ekilltree cannot take a -SIGNAL argument -- you must specify -s=<signal>"
+        # Ensure we don't have any sloppy 'return' statements which don't specify what return code to use. Because this
+        # usually returns the prior return code which is generally not what is intended and causes 'set -e' problems.
+        echo "${CONTENTS}" | egrep '^[^#]*return(\s*;|$)' \
+            && fail "Ambiguous return statements"
 
-    echo "${CONTENTS}" | grep -P '(assert|assert_true|assert_false)\s+\[\[' \
-        && fail "Assert commands cannot be followed by a double bracket expression"
+        echo "${CONTENTS}" | grep -P 'ekill.*-(SIG|TERM|KILL|INT|[0-9])' \
+            && fail "Ekill or ekilltree cannot take a -SIGNAL argument -- you must specify -s=<signal>"
 
-    echo "${CONTENTS}" | egrep '(local|export|declare|readonly)\s+.*=.*\$\(' \
-        && fail "Combined local variable declaration and assignment masks fatal errors"
+        echo "${CONTENTS}" | grep -P '(assert|assert_true|assert_false)\s+\[\[' \
+            && fail "Assert commands cannot be followed by a double bracket expression"
 
-    if [[ ${RC} -eq 0 ]]; then
+        echo "${CONTENTS}" | egrep '(local|export|declare|readonly)\s+.*=.*\$\(' \
+            && fail "Combined local variable declaration and assignment masks fatal errors"
+    fi
+
+    #---- SHELLCHECK ----#
+    # These are mutually exclusive since it is the MINIMUM level to check for
+    if [[ "${shellcheck_style}" -eq 1 ]]; then
+        if ! shellcheck -S style "${fname}"; then
+            fail "Shellcheck (style and above) failed"
+        fi
+    elif [[ "${shellcheck_info}" -eq 1 ]]; then
+        if ! shellcheck -S info "${fname}"; then
+            fail "Shellcheck (info and above) failed"
+        fi
+     elif [[ "${shellcheck_warnings}" -eq 1 ]]; then
+        if ! shellcheck -S warning "${fname}"; then
+            fail "Shellcheck (warnings and above) failed"
+        fi
+     elif [[ "${shellcheck_errors}" -eq 1 ]]; then
+        if ! shellcheck -S error "${fname}"; then
+            fail "Shellcheck (errors) failed"
+        fi
+    fi
+
+    if [[ ${rc} -eq 0 ]]; then
         eend --inline --inline-offset=${einfo_message_length} 0
     else
-        FAILURES+=(${fname})
+        failures+=(${fname})
         eend --inline --inline-offset=${einfo_message_length} 1
     fi
 
-    if [[ "${break}" -eq 1 && ${RC} -ne 0 ]]; then
+    if [[ "${break}" -eq 1 && ${rc} -ne 0 ]]; then
         break
     fi
 done
 
 # Display any errors to STDERR regardless if we've redirected output
-if array_empty FAILURES; then
+if array_empty failures; then
     exit 0
 else
-    eerror "Bashlint detected failures in the following $(lval files=FAILURES)" &>/dev/stderr
-    exit ${#FAILURES[@]}
+    eerror "Bashlint detected failures in the following $(lval files=failures)" &>/dev/stderr
+    exit ${#failures[@]}
 fi

--- a/bin/bashlint
+++ b/bin/bashlint
@@ -7,6 +7,12 @@
 # as published by the Apache Software Foundation, either version 2 of the License, or (at your option) any later
 # version.
 
+#-----------------------------------------------------------------------------------------------------------------------
+#
+# Setup
+#
+#-----------------------------------------------------------------------------------------------------------------------
+
 : ${EBASH_HOME:=$(dirname $0)/..}
 : ${EBASH:=${EBASH_HOME}/share}
 source ${EBASH}/ebash.sh || { echo "Unable to source ${EBASH}/ebash.sh" ; exit 1 ; }
@@ -26,18 +32,28 @@ $(opt_parse \
     "+internal i=1                 | Run all ebash internal checks. This includes checking for bash syntax errors,
                                      non-versioned ebash, deprecated ebash code, ambiguous return statements, combined
                                      local variable declaration and assignment with a subshell result, etc."           \
+    "+git_files                    | Run bashlint on all git files."                                                   \
+    "+git_files_no_modules         | Run bashlint on all git files but skip any files contained inside git modules."   \
     "+shellcheck_errors errors     | Run Shellcheck looking for severity=error."                                       \
     "+shellcheck_warnings warnings | Run Shellcheck looking for severity=warning and above."                           \
     "+shellcheck_info info         | Run Shellcheck looking for severity=warning and above."                           \
     "+shellcheck_style style       | Run Shellcheck looking for severity=warning and above."                           \
 )
 
-if [[ ${quiet} -eq 1 ]]; then
-    exec &> >(edebug)
+# Paths to recursively parse
+if [[ ${git_files_no_modules} -eq 1 ]]; then
+    paths=( $(git ls-files | grep -Fxvf  <(git config --file .gitmodules --name-only --get-regexp path | sed -e 's|submodule.||' -e 's|.path||') | awk -F"/" '{print $1}' | uniq | grep -v "\.") )
+elif [[ ${git_files} -eq 1 ]]; then
+    paths=( $(git ls-files) )
+else
+    paths=( ${@:-.} )
 fi
 
-# Paths to recursively parse
-paths=( ${@:-.} )
+#-----------------------------------------------------------------------------------------------------------------------
+#
+# Helper Functions
+#
+#-----------------------------------------------------------------------------------------------------------------------
 
 # Helper function to display a failure and increment our failure count
 rc=0
@@ -49,7 +65,20 @@ fail()
     rc=1
 }
 
-ebanner "Validating bash scripts" paths opts=$(opt_log)
+#-----------------------------------------------------------------------------------------------------------------------
+#
+# Main
+#
+#-----------------------------------------------------------------------------------------------------------------------
+
+if [[ ${quiet} -eq 1 ]]; then
+    exec &> >(edebug)
+fi
+
+ebanner --uppercase "Bashlint"                                           \
+    files="$(string_truncate -e $(( $(tput cols) - 30 )) "${paths[@]}")" \
+    $(opt_log | sed -e 's|,| |g')
+
 for fname in $(grep -lr '^#!/.*bash' "${paths[@]}" | grep -v '.hg' | sort); do
 
     # If this isn't a bash script skip it

--- a/bin/bashlint
+++ b/bin/bashlint
@@ -75,7 +75,7 @@ if [[ ${quiet} -eq 1 ]]; then
     exec &> >(edebug)
 fi
 
-ebanner --uppercase "Bashlint"                                           \
+ebanner --uppercase "BASHLINT" \
     files="$(string_truncate -e $(( $(tput cols) - 30 )) "${paths[@]}")" \
     $(opt_log | sed -e 's|,| |g')
 

--- a/bin/etest
+++ b/bin/etest
@@ -792,12 +792,12 @@ create_xml()
             local name
 
             # Add all passing tests
-            for name in ${testcases_passed[@]:-}; do
+            for name in "${testcases_passed[@]:-}"; do
                 xml_lines+=( "$(printf '<testcase classname="%s" name="%s" time="%s"></testcase>\n' "${suite}" "${name}" "${TESTS_RUNTIME[$name]}")" )
             done
 
             # Add all failing tests
-            for name in ${testcases_failed[@]:-}; do
+            for name in "${testcases_failed[@]:-}"; do
                 local failure_msg
                 failure_msg="$(printf '<failure message="%s:%s failed" type="ERROR"></failure>' "${suite}" "${name}")"
                 xml_lines+=( "$(printf '<testcase classname="%s" name="%s" time="%s">%s</testcase>\n' "${suite}" "${name}" "${TESTS_RUNTIME[$name]}" "${failure_msg}")" )
@@ -853,7 +853,7 @@ if [[ ${print_only} -eq 1 ]]; then
 
     ebanner --uppercase "ETEST TESTS" OS break exclude filter repeat
 
-    for testname in ${TEST_FILES_TO_RUN[@]}; do
+    for testname in "${TEST_FILES_TO_RUN[@]}"; do
         einfo "${testname}"
         echo "${TEST_FUNCTIONS_TO_RUN[$testname]:-}" | tr ' ' '\n'
     done

--- a/bin/etest
+++ b/bin/etest
@@ -792,12 +792,12 @@ create_xml()
             local name
 
             # Add all passing tests
-            for name in ${testcases_passed[@]:-}; do
+            for name in ${testcases_passed[*]:-}; do
                 xml_lines+=( "$(printf '<testcase classname="%s" name="%s" time="%s"></testcase>\n' "${suite}" "${name}" "${TESTS_RUNTIME[$name]}")" )
             done
 
             # Add all failing tests
-            for name in ${testcases_failed[@]:-}; do
+            for name in ${testcases_failed[*]:-}; do
                 local failure_msg
                 failure_msg="$(printf '<failure message="%s:%s failed" type="ERROR"></failure>' "${suite}" "${name}")"
                 xml_lines+=( "$(printf '<testcase classname="%s" name="%s" time="%s">%s</testcase>\n' "${suite}" "${name}" "${TESTS_RUNTIME[$name]}" "${failure_msg}")" )
@@ -853,7 +853,7 @@ if [[ ${print_only} -eq 1 ]]; then
 
     ebanner --uppercase "ETEST TESTS" OS break exclude filter repeat
 
-    for testname in ${TEST_FILES_TO_RUN[@]}; do
+    for testname in "${TEST_FILES_TO_RUN[@]}"; do
         einfo "${testname}"
         echo "${TEST_FUNCTIONS_TO_RUN[$testname]:-}" | tr ' ' '\n'
     done

--- a/bin/etest
+++ b/bin/etest
@@ -792,12 +792,12 @@ create_xml()
             local name
 
             # Add all passing tests
-            for name in "${testcases_passed[@]:-}"; do
+            for name in ${testcases_passed[@]:-}; do
                 xml_lines+=( "$(printf '<testcase classname="%s" name="%s" time="%s"></testcase>\n' "${suite}" "${name}" "${TESTS_RUNTIME[$name]}")" )
             done
 
             # Add all failing tests
-            for name in "${testcases_failed[@]:-}"; do
+            for name in ${testcases_failed[@]:-}; do
                 local failure_msg
                 failure_msg="$(printf '<failure message="%s:%s failed" type="ERROR"></failure>' "${suite}" "${name}")"
                 xml_lines+=( "$(printf '<testcase classname="%s" name="%s" time="%s">%s</testcase>\n' "${suite}" "${name}" "${TESTS_RUNTIME[$name]}" "${failure_msg}")" )
@@ -853,7 +853,7 @@ if [[ ${print_only} -eq 1 ]]; then
 
     ebanner --uppercase "ETEST TESTS" OS break exclude filter repeat
 
-    for testname in "${TEST_FILES_TO_RUN[@]}"; do
+    for testname in ${TEST_FILES_TO_RUN[@]}; do
         einfo "${testname}"
         echo "${TEST_FUNCTIONS_TO_RUN[$testname]:-}" | tr ' ' '\n'
     done

--- a/bin/selftest
+++ b/bin/selftest
@@ -67,10 +67,8 @@ assert_test_fail()
         assert_match "${output_state}" "${this_test}"
         assert_match "${output_state}" " !! "
 
-        # Make sure the test was listed as FAILED in the log and that it's not in the lists of failed or flaky tests
+        # Make sure the test was listed as FAILED in the log and that it's not in the lists of flaky tests
         assert_match "${ETEST_LOG}" "${this_test} FAILED"
-        assert_not_match "${ETEST_OUTPUT}" "FAILED TESTS:.*${this_test}"
-        assert_not_match "${ETEST_LOG}" "FAILED TESTS:.*${this_test}"
         assert_not_match "${ETEST_OUTPUT}" "FLAKY TESTS:.*${this_test}"
         assert_not_match "${ETEST_LOG}" "FLAKY TESTS:.*${this_test}"
 
@@ -104,10 +102,14 @@ assert_test_pass()
         assert_match "${ETEST_LOG}" "${this_test} PASSED"
 
         # And make sure it's not in either of the lists of failed tests
-        assert_not_match "${ETEST_OUTPUT}" "FAILED TESTS:.*${this_test}"
-        assert_not_match "${ETEST_LOG}" "FAILED TESTS:.*${this_test}"
-        assert_not_match "${ETEST_OUTPUT}" "FLAKY TESTS:.*${this_test}"
-        assert_not_match "${ETEST_LOG}" "FLAKY TESTS:.*${this_test}"
+        # WARNING: Do not check if it is a FLAKY test since this assert is only verifying that it was not ultimately
+        #          marked as a FAILURE. If a test is flaky it may fail the first 2 times and the third time it may pass
+        #          and we'd like to test that it ultimately passes irrespective of flakiness. There is a separate assert
+        #          to check if something is a flaky test or not.
+        ETEST_OUTPUT_NO_FLAKY=$(echo "${ETEST_OUTPUT}" | sed '/FLAKY TESTS:/,$d')
+        ETEST_LOG_NO_FLAKY=$(echo "${ETEST_LOG}"       | sed '/FLAKY TESTS:/,$d')
+        assert_not_match "${ETEST_OUTPUT_NO_FLAKY}" "FAILED TESTS:.*${this_test}"
+        assert_not_match "${ETEST_LOG_NO_FLAKY}" "FAILED TESTS:.*${this_test}"
 
         # Ensure the test is reported in the list of passing tests in the json output file
         jq --raw-output '.testsPassed | .[]' "${ETEST_JSON}" | grep --quiet "${this_test}"
@@ -139,8 +141,10 @@ assert_test_flaky()
         assert_match "${ETEST_LOG}" "${this_test} PASSED"
 
         # And make sure it's not in either of the lists of failed tests
-        assert_not_match "${ETEST_OUTPUT}" "FAILED TESTS:.*${this_test}"
-        assert_not_match "${ETEST_LOG}" "FAILED TESTS:.*${this_test}"
+        ETEST_OUTPUT_NO_FLAKY=$(echo "${ETEST_OUTPUT}" | sed '/FLAKY TESTS:/,$d')
+        ETEST_LOG_NO_FLAKY=$(echo "${ETEST_LOG}"       | sed '/FLAKY TESTS:/,$d')
+        assert_not_match "${ETEST_OUTPUT_NO_FLAKY}" "FAILED TESTS:.*${this_test}"
+        assert_not_match "${ETEST_LOG_NO_FLAKY}" "FAILED TESTS:.*${this_test}"
 
         # And make sure it was reported as a flaky test
         assert_match "${ETEST_OUTPUT}" "FLAKY TESTS:.*${this_test}"
@@ -322,7 +326,7 @@ SELFTEST_flaky_failures_2()
     assert_test_fail flaky_fails_twice
 }
 
-# Flkay test with a test that passes third time and failures=3
+# Flaky test with a test that passes third time and failures=3
 SELFTEST_flaky_failures_3()
 {
     run_etest --filter flaky_fails_twice --failures 3 flaky.etest

--- a/bin/selftest
+++ b/bin/selftest
@@ -387,7 +387,7 @@ array_sort SELFTESTS
 # outside of etest's normal automatic directory deletion that happens after a test run is complete. This allows a
 # test to have a persistent place to store things. This is necessary for our flaky tests where we need to keep track
 # of how many times the test has been executed so we need a persistent place to store that information.
-for selftest in ${SELFTESTS[@]}; do
+for selftest in "${SELFTESTS[@]}"; do
 (
     declare -xg SELFTEST_DIR_OUTPUT
     SELFTEST_DIR_OUTPUT="$(readlink -f output)"

--- a/install/recommends
+++ b/install/recommends
@@ -34,7 +34,6 @@ packages=(
     gdb
     gettext
     gzip
-    shellcheck
     util-linux
 )
 
@@ -64,6 +63,7 @@ if os_distro alpine; then
         ncurses-terminfo
         net-tools
         pstree
+        shellcheck
         xz
     )
 
@@ -83,6 +83,7 @@ elif os_distro arch; then
         git
         jq
         net-tools
+        shellcheck
     )
 
 #----------------------------------------------------------------------------------------------------------------------
@@ -104,6 +105,7 @@ elif os_distro centos; then
         ncurses
         net-tools
         psmisc
+        ShellCheck
         xz
     )
 
@@ -130,6 +132,7 @@ elif os_distro debian; then
         jq
         net-tools
         psmisc
+        shellcheck
         xz-utils
     )
 
@@ -159,6 +162,7 @@ elif os_distro fedora; then
         ncurses
         net-tools
         psmisc
+        ShellCheck
         xz
     )
 
@@ -185,6 +189,7 @@ elif os_distro gentoo; then
         net-tools
         pigz
         psmisc
+        shellcheck-bin
     )
 
 #----------------------------------------------------------------------------------------------------------------------
@@ -215,6 +220,7 @@ elif os_distro ubuntu; then
         mkisofs
         net-tools
         psmisc
+        ShellCheck
         xz-utils
     )
 
@@ -232,6 +238,7 @@ elif os darwin; then
         iproute2mac
         jq
         pstree
+        shellcheck
     )
 
     if ! command_exists docker; then

--- a/install/recommends
+++ b/install/recommends
@@ -17,6 +17,22 @@ END
 
 #----------------------------------------------------------------------------------------------------------------------
 #
+# Helper Functions
+#
+#----------------------------------------------------------------------------------------------------------------------
+
+install_shellcheck()
+{
+    efetch --style=einfo https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz /tmp
+    trap_add "rm -rfv /tmp/shellcheck-stable.linux.x86_64.tar.xz /tmp/shellcheck-stable"
+    mkdir -p "/usr/local/bin"
+    tar --directory "/tmp" --extract --xz --file "/tmp/shellcheck-stable.linux.x86_64.tar.xz"
+    cp -v "/tmp/shellcheck-stable/shellcheck" "/usr/local/bin"
+    command_exists "shellcheck"
+}
+
+#----------------------------------------------------------------------------------------------------------------------
+#
 # All
 #
 #----------------------------------------------------------------------------------------------------------------------
@@ -109,9 +125,7 @@ elif os_distro centos; then
     )
 
     # In CentOS:7 ShellCheck is too old. In CentOS:8 it is not even installable. So use pre-built binary.
-    efetch --style=einfo https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz /tmp
-    mkdir -p "/usr/local/bin"
-    tar --directory "/usr/local/bin" --extract --xz --file "/tmp/shellcheck-stable.linux.x86_64.tar.xz" "shellcheck-stable/shellcheck"
+    install_shellcheck
 
 #----------------------------------------------------------------------------------------------------------------------
 #
@@ -136,14 +150,11 @@ elif os_distro debian; then
         jq
         net-tools
         psmisc
-        shellcheck
         xz-utils
     )
 
     # In debian, ShellCheck is too old so use pre-built binary.
-    efetch --style=einfo https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz /tmp
-    mkdir -p "/usr/local/bin"
-    tar --directory "/usr/local/bin" --extract --xz --file "/tmp/shellcheck-stable.linux.x86_64.tar.xz" "shellcheck-stable/shellcheck"
+    install_shellcheck
 
 #----------------------------------------------------------------------------------------------------------------------
 #
@@ -229,9 +240,11 @@ elif os_distro ubuntu; then
         mkisofs
         net-tools
         psmisc
-        shellcheck
         xz-utils
     )
+
+    # In ubuntu, ShellCheck is too old so use pre-built binary.
+    install_shellcheck
 
 #----------------------------------------------------------------------------------------------------------------------
 #

--- a/install/recommends
+++ b/install/recommends
@@ -105,9 +105,13 @@ elif os_distro centos; then
         ncurses
         net-tools
         psmisc
-        ShellCheck
         xz
     )
+
+    # In CentOS:7 ShellCheck is too old. In CentOS:8 it is not even installable. So use pre-built binary.
+    efetch --style=einfo https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz /tmp
+    mkdir -p "/usr/local/bin"
+    tar --directory "/usr/local/bin" --extract --xz --file "/tmp/shellcheck-stable.linux.x86_64.tar.xz" "shellcheck-stable/shellcheck"
 
 #----------------------------------------------------------------------------------------------------------------------
 #
@@ -135,6 +139,11 @@ elif os_distro debian; then
         shellcheck
         xz-utils
     )
+
+    # In debian, ShellCheck is too old so use pre-built binary.
+    efetch --style=einfo https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz /tmp
+    mkdir -p "/usr/local/bin"
+    tar --directory "/usr/local/bin" --extract --xz --file "/tmp/shellcheck-stable.linux.x86_64.tar.xz" "shellcheck-stable/shellcheck"
 
 #----------------------------------------------------------------------------------------------------------------------
 #
@@ -220,7 +229,7 @@ elif os_distro ubuntu; then
         mkisofs
         net-tools
         psmisc
-        ShellCheck
+        shellcheck
         xz-utils
     )
 

--- a/install/recommends
+++ b/install/recommends
@@ -34,6 +34,7 @@ packages=(
     gdb
     gettext
     gzip
+    shellcheck
     util-linux
 )
 

--- a/share/archive.sh
+++ b/share/archive.sh
@@ -162,7 +162,7 @@ archive_compress_program()
     # Look for matching installed program using which and head -1 to select the first matching program. If progs is
     # empty, this will call 'which ""' which is an error. which returns the number of failed arguments so we have to
     # look at the output and not rely on the return code.
-    which ${progs[@]:-} 2>/dev/null | head -1 || true
+    which "${progs[@]:-}" 2>/dev/null | head -1 || true
 }
 
 opt_usage tar_ignored_modified_files <<'END'
@@ -298,7 +298,7 @@ archive_create()
 
     # In case including and excluding something excludes take precedence.
     if array_not_empty excludes; then
-        array_remove srcs ${excludes[@]}
+        array_remove srcs "${excludes[@]}"
     fi
 
     # Always exclude the destination file. Need to canonicalize it and then remove any illegal prefix characters (/, ./,
@@ -321,7 +321,7 @@ archive_create()
         fi
 
         if array_not_empty excludes; then
-            find ${excludes[@]} -maxdepth 0 2>/dev/null | sed "s|^|${exclude_prefix}|" || true
+            find "${excludes[@]}" -maxdepth 0 2>/dev/null | sed "s|^|${exclude_prefix}|" || true
         fi
 
     done | sort --unique >> "${exclude_file}"
@@ -448,7 +448,7 @@ archive_create()
     fi
 
     # Execute clean-up and clear the list so it won't get called again on trap teardown
-    eunmount --all --recursive --delete ${cleanup_files[@]}
+    eunmount --all --recursive --delete "${cleanup_files[@]}"
     unset cleanup_files
 
     # Propogate any errors
@@ -528,7 +528,7 @@ archive_extract()
                 fi
 
                 # Do the actual extracting
-                cp --archive --recursive --parents ${includes[@]} "${dest_real}"
+                cp --archive --recursive --parents "${includes[@]}" "${dest_real}"
             fi
         )
 
@@ -635,7 +635,7 @@ archive_extract()
 
             # rmdir is noisy about being unable to delete "." but it's not a failure. So use tryrc to capture the
             # return code but only show stderr if the find failed.
-            $(tryrc -r=find_rc -o=find_out -e=find_err find ${orphans[@]} -depth -type d -exec rmdir --parents {} \;)
+            $(tryrc -r=find_rc -o=find_out -e=find_err find "${orphans[@]}" -depth -type d -exec rmdir --parents {} \;)
             assert_zero "${find_rc}" "${find_err}"
         fi
 

--- a/share/array.sh
+++ b/share/array.sh
@@ -35,7 +35,7 @@ array_init_nl works identically to array_init, but always specifies that the del
 END
 array_init_nl()
 {
-    [[ $# -eq 2 ]] || die "array_init_nl requires exactly two parameters but passed=($@)"
+    [[ $# -eq 2 ]] || die "array_init_nl requires exactly two parameters but passed=($*)"
     array_init "$1" "$2" $'\n'
 }
 
@@ -135,7 +135,7 @@ Identical to array_add only hard codes the delimter to be a newline.
 END
 array_add_nl()
 {
-    [[ $# -ne 2 ]] && die "array_add_nl requires exactly two parameters but passed=($@)"
+    [[ $# -ne 2 ]] && die "array_add_nl requires exactly two parameters but passed=($*)"
     array_add "$1" "$2" $'\n'
 }
 
@@ -252,7 +252,7 @@ array_join()
     idx_last=$(echo "${indexes[@]}" | awk '{print $NF}')
 
     local idx
-    for idx in ${indexes[@]}; do
+    for idx in "${indexes[@]}"; do
         eval "echo -n \"\${${__array}[$idx]}\""
 
         # If this is not the last element then always echo the delimiter. If this is the last element only echo the
@@ -268,7 +268,7 @@ Identical to array_join only it hardcodes the dilimter to a newline.
 END
 array_join_nl()
 {
-    [[ $# -ne 1 ]] && die "array_join_nl requires exactly one parameter but passed=($@)"
+    [[ $# -ne 1 ]] && die "array_join_nl requires exactly one parameter but passed=($*)"
     array_join "$1" $'\n'
 }
 
@@ -317,7 +317,7 @@ array_sort()
             local idx
             for idx in $(array_indexes ${__array}); do
                 eval "echo \${${__array}[$idx]}"
-            done | sort ${flags[@]:-}
+            done | sort "${flags[@]:-}"
         )
     done
 }

--- a/share/array.sh
+++ b/share/array.sh
@@ -317,7 +317,7 @@ array_sort()
             local idx
             for idx in $(array_indexes ${__array}); do
                 eval "echo \${${__array}[$idx]}"
-            done | sort ${flags[@]:-}
+            done | sort ${flags[*]:-}
         )
     done
 }

--- a/share/array.sh
+++ b/share/array.sh
@@ -317,7 +317,7 @@ array_sort()
             local idx
             for idx in $(array_indexes ${__array}); do
                 eval "echo \${${__array}[$idx]}"
-            done | sort "${flags[@]:-}"
+            done | sort ${flags[@]:-}
         )
     done
 }

--- a/share/assert.sh
+++ b/share/assert.sh
@@ -72,7 +72,7 @@ assert_false()
     {
         rc=$?
     }
-    [[ ${rc} -ne 0 ]] || die "assert failed (rc=${rc}) :: ${cmd[@]}"
+    [[ ${rc} -ne 0 ]] || die "assert failed (rc=${rc}) :: ${cmd[*]}"
 }
 
 assert_eq()
@@ -136,8 +136,8 @@ assert_match()
 
 assert_not_match()
 {
-    $(opt_parse "?lh" "?rh" "?msg")
-    [[ ! "${lh}" =~ "${rh}" ]] || die "assert_not_match failed [${msg:-}] :: $(lval lh rh)"
+    $(opt_parse "?text" "?regex" "?msg")
+    [[ ! "${text}" =~ ${regex} ]] || die "assert_not_match failed [${msg:-}] :: $(lval text regex)"
 }
 
 assert_zero()

--- a/share/cgroup.sh
+++ b/share/cgroup.sh
@@ -92,10 +92,10 @@ Prior to using a cgroup, you must create it. It is safe to attempt to "create" a
 END
 cgroup_create()
 {
-    edebug "creating cgroups ${@}"
+    edebug "creating cgroups ${*}"
     for cgroup in "${@}" ; do
 
-        for subsystem in ${CGROUP_SUBSYSTEMS[@]} ; do
+        for subsystem in "${CGROUP_SUBSYSTEMS[@]}"; do
             local subsys_path=${CGROUP_SYSFS}/${subsystem}/${cgroup}
             mkdir -p ${subsys_path}
         done
@@ -120,7 +120,7 @@ cgroup_destroy()
 
     for cgroup in "${@}" ; do
 
-        for subsystem in ${CGROUP_SUBSYSTEMS[@]} ; do
+        for subsystem in "${CGROUP_SUBSYSTEMS[@]}"; do
 
             local subsys_path=${CGROUP_SYSFS}/${subsystem}/${cgroup}
             [[ -d ${subsys_path} ]] || { edebug "Skipping ${subsys_path} that is already gone." ; continue ; }
@@ -189,7 +189,7 @@ cgroup_move()
     edebug "$(lval pids cgroup)"
     if array_not_empty pids ; then
         local tmp
-        for subsystem in ${CGROUP_SUBSYSTEMS[@]} ; do
+        for subsystem in "${CGROUP_SUBSYSTEMS[@]}"; do
             tmp="$(array_join_nl pids)"
             echo -e "${tmp}" > ${CGROUP_SYSFS}/${subsystem}/${cgroup}/tasks
         done
@@ -318,7 +318,7 @@ cgroup_ps()
     [[ ${recursive} -eq 1 ]] && options+=("-r")
 
     local pid cgroup_pids
-    cgroup_pids=($(cgroup_pids ${options[@]:-} -x="${BASHPID} ${exclude}" ${cgroup}))
+    cgroup_pids=($(cgroup_pids "${options[@]:-}" -x="${BASHPID} ${exclude}" "${cgroup}"))
 
     array_empty cgroup_pids && return 0
 
@@ -449,7 +449,7 @@ cgroup_kill()
 
     # NOTE: BASHPID must be added here in addition to above because it's different inside this command substituion
     # (subshell) than it is outside.
-    array_init pids "$(cgroup_pids -r -x="${ignorepids} ${BASHPID}" ${cgroups[@]} || true)"
+    array_init pids "$(cgroup_pids -r -x="${ignorepids} ${BASHPID}" "${cgroups[@]}" || true)"
 
     if [[ $(array_size pids) -gt 0 ]] ; then
         edebug "Killing processes in cgroups $(lval signal cgroups pids ignorepids)"
@@ -459,7 +459,7 @@ cgroup_kill()
         #
         # NOTE: This also has the side effect of causing cgroup_kill to NOT fail when the calling user doesn't have
         # permission to kill everything in the cgroup.
-        ekill -s=${signal} ${pids[@]} || true
+        ekill -s=${signal} "${pids[@]}" || true
     else
         edebug "All processes in cgroup are already dead. $(lval cgroups pids ignorepids)"
     fi

--- a/share/checkbox.sh
+++ b/share/checkbox.sh
@@ -13,7 +13,7 @@ filled in with a successful check mark or with a failing X. This is useful to di
 END
 checkbox_open()
 {
-    echo -n "$(tput setaf 209)$(tput bold)[ ]$(tput sgr0) ${@}" >&2
+    echo -n "$(tput setaf 209)$(tput bold)[ ]$(tput sgr0) ${*}" >&2
 }
 
 opt_usage checkbox_open_timer <<'END'
@@ -34,7 +34,7 @@ checkbox_open_timer()
         while true; do
             now=${SECONDS}
             diff=$(( ${now} - ${start} ))
-            printf "$(tput setaf 209)$(tput bold)[ ]$(tput sgr0) %-20s" "$@"
+            printf "$(tput setaf 209)$(tput bold)[ ]$(tput sgr0) %-20s" "$*"
             printf " $(tput bold)[%02d:%02d:%02d]\r$(tput sgr0)" $(( ${diff} / 3600 )) $(( (${diff} % 3600) / 60 )) $(( ${diff} % 60 ))
 
             # Optionally display a newline between each ticker. This is helpful from jenkins jobs where we want to see
@@ -92,7 +92,7 @@ checkbox is a simple function to display a checkbox at the start of the line fol
 END
 checkbox()
 {
-    echo "$(tput setaf 2)$(tput bold)[✓]$(tput sgr0) ${@}" >&2
+    echo "$(tput setaf 2)$(tput bold)[✓]$(tput sgr0) ${*}" >&2
 }
 
 opt_usage checkbox_passed <<'END'
@@ -101,7 +101,7 @@ optional message.
 END
 checkbox_passed()
 {
-    echo -e "$(tput setaf 2)$(tput bold)[✓] PASSED$(tput sgr0) ${@}" >&2
+    echo -e "$(tput setaf 2)$(tput bold)[✓] PASSED$(tput sgr0) ${*}" >&2
 }
 
 opt_usage checkbox_failed <<'END'
@@ -110,5 +110,5 @@ message.
 END
 checkbox_failed()
 {
-    echo -e "$(tput setaf 1)$(tput bold)[✘] FAILED$(tput sgr0) ${@}" >&2
+    echo -e "$(tput setaf 1)$(tput bold)[✘] FAILED$(tput sgr0) ${*}" >&2
 }

--- a/share/chroot.sh
+++ b/share/chroot.sh
@@ -31,8 +31,8 @@ chroot_unmount()
     einfo "Unmounting $(lval CHROOT CHROOT_MOUNTS)"
 
     local mounts=()
-    array_init_nl mounts "$(echo "${CHROOT_MOUNTS[@]}" | sed 's| |\n|g' | sort -r)"
-    for m in "${mounts[@]}" ; do
+    array_init_nl mounts "$(echo ${CHROOT_MOUNTS[@]} | sed 's| |\n|g' | sort -r)"
+    for m in ${mounts[@]} ; do
         eunmount "${CHROOT}${m}"
     done
 }

--- a/share/chroot.sh
+++ b/share/chroot.sh
@@ -19,7 +19,7 @@ chroot_mount()
     argcheck CHROOT
     einfo "Mounting $(lval CHROOT CHROOT_MOUNTS)"
 
-    for m in ${CHROOT_MOUNTS[@]}; do
+    for m in "${CHROOT_MOUNTS[@]}"; do
         mkdir -p ${CHROOT}${m}
         ebindmount ${m} ${CHROOT}${m}
     done
@@ -31,7 +31,7 @@ chroot_unmount()
     einfo "Unmounting $(lval CHROOT CHROOT_MOUNTS)"
 
     local mounts=()
-    array_init_nl mounts "$(echo ${CHROOT_MOUNTS[@]} | sed 's| |\n|g' | sort -r)"
+    array_init_nl mounts "$(echo "${CHROOT_MOUNTS[@]}" | sed 's| |\n|g' | sort -r)"
     for m in "${mounts[@]}" ; do
         eunmount "${CHROOT}${m}"
     done
@@ -94,7 +94,7 @@ chroot_cmd()
 {
     argcheck CHROOT
 
-    edebug "[${CHROOT}] $@"
+    edebug "[${CHROOT}] $*"
     chroot ${CHROOT} ${CHROOT_ENV} -c "$*"
 }
 
@@ -124,7 +124,7 @@ chroot_kill()
     fi
 
     local pid
-    for pid in ${pids[@]}; do
+    for pid in "${pids[@]}"; do
         einfos "Killing ${pid} [$(ps -p ${pid} -o comm=)]"
         ekilltree --signal=${signal} --kill-after=${kill_after} ${pid}
     done
@@ -217,7 +217,7 @@ chroot_install_with_apt_get()
     argcheck CHROOT
     [[ $# -eq 0 ]] && return 0
 
-    edebug "[${CHROOT}] Installing $@"
+    edebug "[${CHROOT}] Installing $*"
     chroot ${CHROOT} ${CHROOT_ENV} -c "apt-get -f -qq -y --force-yes install $*"
 }
 
@@ -237,7 +237,7 @@ chroot_install()
     argcheck CHROOT
     [[ $# -eq 0 ]] && return 0
 
-    einfos "Installing $@"
+    einfos "Installing $*"
 
     # Check if all packages are installable
     chroot_install_check $*
@@ -247,7 +247,7 @@ chroot_install()
 
     # Post-install validation because ubuntu is entirely stupid and apt-get and aptitude can return success even though
     # the package is not installed successfully
-    for p in $@; do
+    for p in "$@"; do
 
         local pn=${p}
         local pv=""
@@ -279,7 +279,7 @@ chroot_uninstall()
     argcheck CHROOT
     [[ $# -eq 0 ]] && return 0
 
-    einfos "Uninstalling $@"
+    einfos "Uninstalling $*"
     chroot ${CHROOT} ${CHROOT_ENV} -c "${CHROOT_APT} remove --purge $*"
 }
 
@@ -288,7 +288,7 @@ chroot_dpkg()
     argcheck CHROOT
     [[ $# -eq 0 ]] && return 0
 
-    edebug "[${CHROOT}] dpkg $@"
+    edebug "[${CHROOT}] dpkg $*"
     chroot ${CHROOT} ${CHROOT_ENV} -c "dpkg $*"
 }
 
@@ -297,7 +297,7 @@ chroot_apt()
     argcheck CHROOT
     [[ $# -eq 0 ]] && return 0
 
-    edebug "[${CHROOT}] ${CHROOT_APT} $@"
+    edebug "[${CHROOT}] ${CHROOT_APT} $*"
     chroot ${CHROOT} ${CHROOT_ENV} -c "${CHROOT_APT} $*"
 }
 

--- a/share/chroot.sh
+++ b/share/chroot.sh
@@ -31,8 +31,8 @@ chroot_unmount()
     einfo "Unmounting $(lval CHROOT CHROOT_MOUNTS)"
 
     local mounts=()
-    array_init_nl mounts "$(echo ${CHROOT_MOUNTS[@]} | sed 's| |\n|g' | sort -r)"
-    for m in ${mounts[@]} ; do
+    array_init_nl mounts "$(echo "${CHROOT_MOUNTS[@]}" | sed 's| |\n|g' | sort -r)"
+    for m in "${mounts[@]}"; do
         eunmount "${CHROOT}${m}"
     done
 }

--- a/share/daemon.sh
+++ b/share/daemon.sh
@@ -249,7 +249,7 @@ daemon_start()
                     if [[ -n ${bindmounts} ]]; then
                         local mounts=( ${bindmounts} )
                         local mnt
-                        for mnt in ${mounts[@]}; do
+                        for mnt in "${mounts[@]}"; do
                             local src="${mnt%%:*}"
                             local dest="${mnt#*:}"
                             [[ -z ${dest} ]] && dest="${src}"

--- a/share/daemon.sh
+++ b/share/daemon.sh
@@ -249,7 +249,7 @@ daemon_start()
                     if [[ -n ${bindmounts} ]]; then
                         local mounts=( ${bindmounts} )
                         local mnt
-                        for mnt in "${mounts[@]}"; do
+                        for mnt in ${mounts[@]}; do
                             local src="${mnt%%:*}"
                             local dest="${mnt#*:}"
                             [[ -z ${dest} ]] && dest="${src}"

--- a/share/dialog.sh
+++ b/share/dialog.sh
@@ -106,6 +106,8 @@ dialog()
         dialog_args+=( "${@}" )
 
         # Use quote_eval so that any nested quotes and whitespace inside dialog_args are preserved properly.
+        # shellcheck disable=SC2145
+        # We do not want to use $* here as it collapses whitespace that we want preserved.
         if quote_eval "command dialog --colors ${dialog_args[@]}"; then
             echo 0 > "${rc_file}"
         else
@@ -180,6 +182,8 @@ usage to `eerror` and will display a dialog msgbox with the provided text.
 END
 dialog_error()
 {
+    # shellcheck disable=SC2145
+    # We do not want to use $* here as it collapses whitespace that we want preserved.
     $(dialog --no-cancel --colors --title "Error" --msgbox "\Zb\Z1$@" 10 50)
     return 0
 }
@@ -956,7 +960,7 @@ __dialog_select_list()
     (
         __EBASH_INSIDE_TRY=1
         disable_die_parent
-        eval "columns=( \"\${$__array[@]}\" )"
+        eval "columns=( \"\${${__array}[@]}\" )"
 
         if command dialog --colors "${dialog_args[@]}" "${columns[@]}"; then
             echo 0 > "${rc_file}"

--- a/share/dialog.sh
+++ b/share/dialog.sh
@@ -106,7 +106,7 @@ dialog()
         dialog_args+=( "${@}" )
 
         # Use quote_eval so that any nested quotes and whitespace inside dialog_args are preserved properly.
-        if quote_eval "command dialog --colors ${dialog_args[*]}"; then
+        if quote_eval "command dialog --colors ${dialog_args[@]}"; then
             echo 0 > "${rc_file}"
         else
             echo $? > "${rc_file}"
@@ -180,7 +180,7 @@ usage to `eerror` and will display a dialog msgbox with the provided text.
 END
 dialog_error()
 {
-    $(dialog --no-cancel --colors --title "Error" --msgbox "\Zb\Z1$*" 10 50)
+    $(dialog --no-cancel --colors --title "Error" --msgbox "\Zb\Z1$@" 10 50)
     return 0
 }
 
@@ -956,7 +956,7 @@ __dialog_select_list()
     (
         __EBASH_INSIDE_TRY=1
         disable_die_parent
-        eval "columns=( \"\${${__array}[@]}\" )"
+        eval "columns=( \"\${$__array[@]}\" )"
 
         if command dialog --colors "${dialog_args[@]}" "${columns[@]}"; then
             echo 0 > "${rc_file}"

--- a/share/dialog.sh
+++ b/share/dialog.sh
@@ -106,7 +106,7 @@ dialog()
         dialog_args+=( "${@}" )
 
         # Use quote_eval so that any nested quotes and whitespace inside dialog_args are preserved properly.
-        if quote_eval "command dialog --colors ${dialog_args[@]}"; then
+        if quote_eval "command dialog --colors ${dialog_args[*]}"; then
             echo 0 > "${rc_file}"
         else
             echo $? > "${rc_file}"
@@ -180,7 +180,7 @@ usage to `eerror` and will display a dialog msgbox with the provided text.
 END
 dialog_error()
 {
-    $(dialog --no-cancel --colors --title "Error" --msgbox "\Zb\Z1$@" 10 50)
+    $(dialog --no-cancel --colors --title "Error" --msgbox "\Zb\Z1$*" 10 50)
     return 0
 }
 
@@ -654,7 +654,7 @@ dialog_prompt()
                 continue 2
             fi
 
-            # Update focus if we are sending the ENTER key 
+            # Update focus if we are sending the ENTER key
             if [[ "${char}" == "${EBASH_KEY_ENTER}" ]]; then
                 focus=1
             fi
@@ -956,7 +956,7 @@ __dialog_select_list()
     (
         __EBASH_INSIDE_TRY=1
         disable_die_parent
-        eval "columns=( \"\${$__array[@]}\" )"
+        eval "columns=( \"\${${__array}[@]}\" )"
 
         if command dialog --colors "${dialog_args[@]}" "${columns[@]}"; then
             echo 0 > "${rc_file}"

--- a/share/die.sh
+++ b/share/die.sh
@@ -252,5 +252,5 @@ nodie_on_abort()
 
     local signals=( "${@}" )
     [[ ${#signals[@]} -gt 0 ]] || signals=( ${DIE_SIGNALS[@]} )
-    trap - ${signals[@]}
+    trap - "${signals[@]}"
 }

--- a/share/docker.sh
+++ b/share/docker.sh
@@ -158,7 +158,7 @@ docker_build()
         docker history "${image}" > "${histfile}"
         docker inspect "${image}" > "${inspfile}"
 
-        opt_forward docker_pull image registry username password cache_from -- "${tag[@]:-}"
+        opt_forward docker_pull image registry username password cache_from -- ${tag[*]:-}
 
         return 0
 
@@ -170,7 +170,7 @@ docker_build()
             docker history "${image}" > "${histfile}"
             docker inspect "${image}" > "${inspfile}"
 
-            opt_forward docker_pull image registry username password cache_from -- "${tag[@]:-}"
+            opt_forward docker_pull image registry username password cache_from -- ${tag[*]:-}
 
             return 0
         fi
@@ -216,7 +216,7 @@ docker_build()
     if [[ ${push} -eq 1 ]]; then
         local push_tags
         push_tags=( ${image} ${tag[@]:-} )
-        opt_forward docker_push registry username password -- "${push_tags[@]}"
+        opt_forward docker_push registry username password -- ${push_tags[*]}
     fi
 
     # Only create inspect (stamp) file at the very end after everything has been done.
@@ -505,7 +505,7 @@ __docker_depends_sha()
     fi
 
     local sha_detail=""
-    sha_detail+="$(find "${depends[@]}" "${exclude}" -type f -print0 \
+    sha_detail+="$(find ${depends[*]} ${exclude} -type f -print0 \
         | sort -z \
         | xargs -0 "${shafunc}sum" \
         | awk '{print $2"'@${shafunc}:'"$1}'

--- a/share/docker.sh
+++ b/share/docker.sh
@@ -158,7 +158,7 @@ docker_build()
         docker history "${image}" > "${histfile}"
         docker inspect "${image}" > "${inspfile}"
 
-        opt_forward docker_pull image registry username password cache_from -- ${tag[@]:-}
+        opt_forward docker_pull image registry username password cache_from -- "${tag[@]:-}"
 
         return 0
 
@@ -170,7 +170,7 @@ docker_build()
             docker history "${image}" > "${histfile}"
             docker inspect "${image}" > "${inspfile}"
 
-            opt_forward docker_pull image registry username password cache_from -- ${tag[@]:-}
+            opt_forward docker_pull image registry username password cache_from -- "${tag[@]:-}"
 
             return 0
         fi
@@ -216,7 +216,7 @@ docker_build()
     if [[ ${push} -eq 1 ]]; then
         local push_tags
         push_tags=( ${image} ${tag[@]:-} )
-        opt_forward docker_push registry username password -- ${push_tags[@]}
+        opt_forward docker_push registry username password -- "${push_tags[@]}"
     fi
 
     # Only create inspect (stamp) file at the very end after everything has been done.
@@ -505,7 +505,7 @@ __docker_depends_sha()
     fi
 
     local sha_detail=""
-    sha_detail+="$(find ${depends[@]} ${exclude} -type f -print0 \
+    sha_detail+="$(find "${depends[@]}" "${exclude}" -type f -print0 \
         | sort -z \
         | xargs -0 "${shafunc}sum" \
         | awk '{print $2"'@${shafunc}:'"$1}'

--- a/share/dpkg.sh
+++ b/share/dpkg.sh
@@ -82,7 +82,7 @@ dpkg_depends()
             dpkg_compare_versions "${apv}" "==" "${pv}" || die "Version mismatch: wanted=[${pn}-${pv}] actual=[${apn}-${apv}] op=[${op}]"
 
             echo ${fname}
-            for d in $(dpkg_depends ${dir}/${pn}.deb ${tag}); do
+            for d in $(dpkg_depends "${dir}/${pn}.deb" "${tag}"); do
                 echo $d
             done
         else
@@ -93,14 +93,18 @@ dpkg_depends()
 
 dpkg_depends_deb()
 {
-    for p in $(dpkg_depends $@); do
-        [[ ${p: -4} == ".deb" ]] && echo ${p} || true
+    for p in $(dpkg_depends "${@}"); do
+        if [[ ${p: -4} == ".deb" ]]; then
+            echo "${p}"
+        fi
     done
 }
 
 dpkg_depends_apt()
 {
-    for p in $(dpkg_depends $@); do
-        [[ ${p: -4} != ".deb" ]] && echo ${p} || true
+    for p in $(dpkg_depends "${@}"); do
+        if [[ ${p: -4} != ".deb" ]]; then
+            echo "${p}"
+        fi
     done
 }

--- a/share/efetch.sh
+++ b/share/efetch.sh
@@ -195,7 +195,7 @@ END
 __efetch_download()
 {
     local url=""
-    for url in ${!data[@]}; do
+    for url in "${!data[@]}"; do
         $(pack_import data[$url])
 
         # Call curl with explicit COLUMNS so that the progress bar will fit into the amount of room left on the
@@ -242,7 +242,7 @@ __efetch_download_wait()
 
     while [[ ${#finished[@]} -lt ${#data[@]} ]]; do
 
-        for url in ${urls[@]}; do
+        for url in "${urls[@]}"; do
             $(pack_import data[$url])
 
             # This is where all the pretty output formatting happens. We basically move the cursor to the start of the
@@ -297,7 +297,7 @@ __efetch_check_incomplete_or_failed()
 {
     # Move files to their final destinations or remove pending files for failed downloads
     local url
-    for url in ${!data[@]}; do
+    for url in "${!data[@]}"; do
         $(pack_import data[$url])
 
         rm --force "${progress}"
@@ -337,7 +337,7 @@ __efetch_digest_validation()
     fi
 
     local url
-    for url in ${!data[@]}; do
+    for url in "${!data[@]}"; do
         $(pack_import data[$url])
 
         if [[ "${dest##*.}" == @(md5|meta) ]]; then

--- a/share/elock.sh
+++ b/share/elock.sh
@@ -145,5 +145,5 @@ because `flock` doesn't provide a native way to check if we have a file locked o
 END
 elock_unlocked()
 {
-    ! elock_locked $@
+    ! elock_locked "${@}"
 }

--- a/share/elogfile.sh
+++ b/share/elogfile.sh
@@ -112,6 +112,8 @@ elogfile()
                 nodie_on_error
 
                 if [[ ${tail} -eq 1 ]]; then
+                    # shellcheck disable=SC2261
+                    # This tee is carefully constructed to send stdout to a named file descriptor so disable shellcheck
                     tee -a "${files[@]}" <${pipe} >&$(get_stream_fd ${name}) 2>/dev/null
                 else
                     tee -a "${files[@]}" <${pipe} >/dev/null 2>&1

--- a/share/elogfile.sh
+++ b/share/elogfile.sh
@@ -104,7 +104,7 @@ elogfile()
                 #
                 # This will keep them alive long enough to display our error output and such. SIGPIPE will take care of
                 # them, and the kill -9 below will make double sure.
-                trap "" ${TTY_SIGNALS[@]}
+                trap "" "${TTY_SIGNALS[@]}"
                 echo "${BASHPID}" >${pid_pipe}
 
                 # Past this point, we hand control to the tee processes which we expect to die in their own time. We no

--- a/share/emetadata.sh
+++ b/share/emetadata.sh
@@ -176,7 +176,7 @@ emetadata_check()
     # Now validate all digests we found
     local pids=()
     local ctype
-    for ctype in ${digests[@]}; do
+    for ctype in "${digests[@]}"; do
 
         expect=$(pack_get metapack ${ctype})
 
@@ -225,7 +225,7 @@ emetadata_check()
     done
 
     # Wait for all pids and then assert the return code was zero.
-    wait ${pids[@]} && rc=0 || rc=$?
+    wait "${pids[@]}" && rc=0 || rc=$?
     if [[ ${quiet} -ne 1 ]]; then
         eprogress_kill -r=${rc}
     fi

--- a/share/emsg.sh
+++ b/share/emsg.sh
@@ -401,6 +401,8 @@ ecolor()
 ecolor_internal()
 {
     local c=""
+    # We want to re-split the provided list of options on whitespace so disable shellcheck for this line
+    # shellcheck disable=SC2068
     for c in $@; do
         case ${c} in
             dim)                echo -en "\033[2m"                 ;;
@@ -484,24 +486,24 @@ ebanner()
         opt_forward expand_vars uppercase lowercase -- details "${@}"
 
         # Now output all the details (if any)
-        if [[ -n ${details[@]:-} ]]; then
-            ecolor ${COLOR_BANNER}
+        if [[ -n "${details[*]:-}" ]]; then
+            ecolor "${COLOR_BANNER}"
             echo -e "|"
 
             # Sort the keys and store into an array
             local keys
-            keys=( $(for key in ${!details[@]}; do echo "${key}"; done | sort) )
+            keys=( $(for key in "${!details[@]}"; do echo "${key}"; done | sort) )
 
             # Figure out the longest key
             local longest=0
-            for key in ${keys[@]}; do
+            for key in "${keys[@]}"; do
                 local len=${#key}
                 (( len > longest )) && longest=$len
             done
 
             # Iterate over the keys of the associative array and print out the values
             local pad="" ktag=""
-            for key in ${keys[@]}; do
+            for key in "${keys[@]}"; do
                 pad=$((longest-${#key}+1))
                 ktag="${key}"
 
@@ -510,7 +512,7 @@ ebanner()
                     ktag="${ktag^^}"
                 fi
 
-                ecolor ${COLOR_BANNER}
+                ecolor "${COLOR_BANNER}"
                 printf "| • %s%${pad}s :: %s\n" ${ktag} " " "${details[$key]}"
             done
         fi
@@ -671,7 +673,7 @@ tput()
         return 0
     fi
 
-    command tput $@ || true
+    command tput "$@" || true
 }
 
 opt_usage einfo <<'END'
@@ -895,7 +897,7 @@ eprogress()
 
         # Sentinal for breaking out of the loop on signal from eprogress_kill
         local done=0
-        trap "done=1" ${DIE_SIGNALS[@]}
+        trap "done=1" "${DIE_SIGNALS[@]}"
 
         # Display static message.
         "${style}" -n "$*"
@@ -1019,7 +1021,7 @@ eprogress_kill()
 
     # Kill requested eprogress pids
     local pid
-    for pid in ${pids[@]}; do
+    for pid in "${pids[@]}"; do
 
         # Don't kill the pid if it's not running or it's not an eprogress pid. This catches potentially disasterous
         # errors where someone would do "eprogress_kill ${rc}" when they really meant "eprogress_kill -r=${rc}"

--- a/share/emsg.sh
+++ b/share/emsg.sh
@@ -1081,7 +1081,7 @@ print_value()
     local __array_regex="declare -a"
     local __assoc_regex="declare -A"
     if [[ ${__decl} =~ ${__array_regex} ]] ; then
-        if [[ BASH_VERSINFO[0] -ge 5 || ( BASH_VERSINFO[0] -eq 4 && BASH_VERSINFO[1] -gt 3 ) ]] ; then
+        if [[ ${BASH_VERSINFO[0]} -ge 5 || ( ${BASH_VERSINFO[0]} -eq 4 && ${BASH_VERSINFO[1]} -gt 3 ) ]] ; then
             # BASH 4.4 and beyond -- no single quote
             __val=$(declare -p ${__input} | sed -e "s/[^=]*=(\(.*\))/(\1)/" -e "s/[[[:digit:]]\+]=//g")
         else

--- a/share/eprompt.sh
+++ b/share/eprompt.sh
@@ -18,7 +18,7 @@ eprompt()
     $(opt_parse \
         "+silent s | Be silent and do not echo input coming from the terminal.")
 
-    echo -en "$(ecolor bold) * $@: $(ecolor none)" >&2
+    echo -en "$(ecolor bold) * $*: $(ecolor none)" >&2
     local result=""
 
     if [[ "${silent}" -eq 1 ]]; then

--- a/share/eretry.sh
+++ b/share/eretry.sh
@@ -106,7 +106,7 @@ eretry_internal()
     warn_every=${warn_every%s}
 
     # If no command to execute just return success immediately
-    if [[ -z "${cmd[@]:-}" ]]; then
+    if [[ -z "${cmd[*]:-}" ]]; then
         return 0
     fi
 

--- a/share/etable.sh
+++ b/share/etable.sh
@@ -209,7 +209,7 @@ __etable_internal_ascii()
     local idx=0
 
     local len=0
-    for idx in ${column_indexes[@]}; do
+    for idx in "${column_indexes[@]}"; do
         len=$((lengths[$idx]+2))
         (( divider_len += len ))
 
@@ -268,7 +268,7 @@ __etable_internal_ascii()
         printf "${symbols[vertical_line]}"
 
         local idx=0
-        for idx in ${column_indexes[@]}; do
+        for idx in "${column_indexes[@]}"; do
             part=${parts[$idx]:-}
             part_len=$(echo -n "${part}" | noansi | wc -c)
             pad=$(( lengths[$idx] - part_len + 1 ))

--- a/share/etable.sh
+++ b/share/etable.sh
@@ -209,7 +209,7 @@ __etable_internal_ascii()
     local idx=0
 
     local len=0
-    for idx in ${column_indexes[@]}; do
+    for idx in ${column_indexes[*]}; do
         len=$((lengths[$idx]+2))
         (( divider_len += len ))
 
@@ -268,7 +268,7 @@ __etable_internal_ascii()
         printf "${symbols[vertical_line]}"
 
         local idx=0
-        for idx in ${column_indexes[@]}; do
+        for idx in ${column_indexes[*]}; do
             part=${parts[$idx]:-}
             part_len=$(echo -n "${part}" | noansi | wc -c)
             pad=$(( lengths[$idx] - part_len + 1 ))

--- a/share/etable.sh
+++ b/share/etable.sh
@@ -209,7 +209,7 @@ __etable_internal_ascii()
     local idx=0
 
     local len=0
-    for idx in "${column_indexes[@]}"; do
+    for idx in ${column_indexes[@]}; do
         len=$((lengths[$idx]+2))
         (( divider_len += len ))
 
@@ -268,7 +268,7 @@ __etable_internal_ascii()
         printf "${symbols[vertical_line]}"
 
         local idx=0
-        for idx in "${column_indexes[@]}"; do
+        for idx in ${column_indexes[@]}; do
             part=${parts[$idx]:-}
             part_len=$(echo -n "${part}" | noansi | wc -c)
             pad=$(( lengths[$idx] - part_len + 1 ))

--- a/share/etimeout.sh
+++ b/share/etimeout.sh
@@ -37,7 +37,7 @@ etimeout()
     local start=${SECONDS}
 
     # If no command to execute just return success immediately
-    if [[ -z "${cmd[@]:-}" ]]; then
+    if [[ -z "${cmd[*]:-}" ]]; then
         return 0
     fi
 

--- a/share/exec.sh
+++ b/share/exec.sh
@@ -52,6 +52,10 @@ reexec()
     fi
     unset __EBASH_REEXEC_CMD
 }
+
+# Normally shellcheck is right here but we are defering this expansion until the alias is invoked and it does exactly
+# what we expect in this particular case.
+# shellcheck disable=SC2142
 alias reexec='declare -a __EBASH_REEXEC_CMD=("$0" "$@") ; reexec'
 
 opt_usage quote_eval <<'END'

--- a/share/mount.sh
+++ b/share/mount.sh
@@ -270,8 +270,8 @@ this is just a passthrough operation into mount you should see mount(8) manpage 
 END
 emount()
 {
-    if edebug_enabled || [[ "${*}" =~ (^| )(-v|--verbose)( |$) ]]; then
-        einfos "Mounting $*"
+    if edebug_enabled || [[ "${@}" =~ (^| )(-v|--verbose)( |$) ]]; then
+        einfos "Mounting $@"
     fi
 
     mount "${@}"
@@ -283,7 +283,7 @@ eunmount_internal()
         "+verbose v | Verbose output.")
 
     local mnt mnt_type
-    for mnt in "$@"; do
+    for mnt in $@; do
 
         # Skip if not mounted.
         emounted "${mnt}" || continue
@@ -318,7 +318,7 @@ eunmount()
     fi
 
     local mnt
-    for mnt in "$@"; do
+    for mnt in $@; do
 
         # If empty string just skip it
         [[ -z "${mnt}" ]] && continue
@@ -354,7 +354,7 @@ eunmount()
 
                 # Lazily unmount all mounts
                 local match
-                for match in "${matches[@]}"; do
+                for match in ${matches[@]}; do
                     opt_forward eunmount_internal verbose -- "${match}"
                 done
             fi

--- a/share/mount.sh
+++ b/share/mount.sh
@@ -270,8 +270,8 @@ this is just a passthrough operation into mount you should see mount(8) manpage 
 END
 emount()
 {
-    if edebug_enabled || [[ "${@}" =~ (^| )(-v|--verbose)( |$) ]]; then
-        einfos "Mounting $@"
+    if edebug_enabled || [[ "${*}" =~ (^| )(-v|--verbose)( |$) ]]; then
+        einfos "Mounting $*"
     fi
 
     mount "${@}"
@@ -283,7 +283,7 @@ eunmount_internal()
         "+verbose v | Verbose output.")
 
     local mnt mnt_type
-    for mnt in $@; do
+    for mnt in "$@"; do
 
         # Skip if not mounted.
         emounted "${mnt}" || continue
@@ -318,7 +318,7 @@ eunmount()
     fi
 
     local mnt
-    for mnt in $@; do
+    for mnt in "$@"; do
 
         # If empty string just skip it
         [[ -z "${mnt}" ]] && continue
@@ -354,7 +354,7 @@ eunmount()
 
                 # Lazily unmount all mounts
                 local match
-                for match in ${matches[@]}; do
+                for match in "${matches[@]}"; do
                     opt_forward eunmount_internal verbose -- "${match}"
                 done
             fi

--- a/share/netns.sh
+++ b/share/netns.sh
@@ -186,6 +186,6 @@ netns_chroot_exec()
 
     $(pack_import ${netns_args_packname} ns_name)
 
-    edebug "Executing command in namespace [${ns_name}] and chroot [${chroot_root}]: ${cmd[@]}"
+    edebug "Executing command in namespace [${ns_name}] and chroot [${chroot_root}]: ${cmd[*]}"
     netns_exec ${ns_name} chroot "${chroot_root}" "${cmd[@]}"
 }

--- a/share/network.sh
+++ b/share/network.sh
@@ -226,8 +226,8 @@ get_network_interfaces_with_port()
 
     for ifname in $(get_network_interfaces); do
         port=$(ethtool ${ifname} | grep "Supported ports:" || true)
-        for query in $@; do
-            if [[ ${port} =~ "${query}" ]]; then
+        for query in "$@"; do
+            if [[ ${port} =~ ${query} ]]; then
                 results+=( "${ifname}" )
                 break
             fi
@@ -452,7 +452,7 @@ netselect()
     array_init_nl sorted "$(printf '%s\n' "${results[@]}" | sort -t\| -k5 -n)"
     array_init_nl rows "Server|Latency|Jitter|Loss|Score"
 
-    for entry in ${sorted[@]} ; do
+    for entry in "${sorted[@]}"; do
         array_init parts "${entry}" "|"
         array_add_nl rows "${parts[0]}|${parts[1]}|${parts[2]}|${parts[3]}|${parts[4]}"
     done
@@ -465,7 +465,7 @@ netselect()
 
         ## SHOW ALL RESULTS ##
         einfos "All results:"
-        etable ${rows[@]} >&2
+        etable "${rows[@]}" >&2
 
         einfos "Best host=[${best}]"
     fi

--- a/share/network.sh
+++ b/share/network.sh
@@ -8,7 +8,7 @@
 # version.
 
 # Set root of sysfs tree for easier mockability in unit tests
-: ${EBASH_SYSFS:=/sys}
+: ${__EBASH_SYSFS:=/sys}
 
 opt_usage valid_ip <<'END'
 Check if a given input is a syntactically valid IP Address.
@@ -209,9 +209,9 @@ get_network_interfaces()
         networksetup -listallhardwareports | awk '/Hardware Port: Wi-Fi/{getline; print $2}'
     fi
 
-    for iface in $(ls -1 ${EBASH_SYSFS}/class/net); do
+    for iface in $(ls -1 ${__EBASH_SYSFS}/class/net); do
         # Skip virtual devices, we only want physical
-        [[ ! -e ${EBASH_SYSFS}/class/net/${iface}/device ]] && continue
+        [[ ! -e ${__EBASH_SYSFS}/class/net/${iface}/device ]] && continue
         echo "${iface}"
     done | tr '\n' ' ' || true
 }
@@ -257,20 +257,20 @@ opt_usage get_permanent_mac_address <<'END'
 Get the permanent MAC address for given ifname.
 
 > **_NOTE:_** `ethtool -P` is not reliable on all cards since the firmware has to support it properly. So on Linux we
-instead look in EBASH_SYSFS since this is far more reliable as we're talking direct to the kernel. But on OSX we instead
-just use ethtool.
+instead look in __EBASH_SYSFS since this is far more reliable as we're talking direct to the kernel. But on OSX we
+instead just use ethtool.
 END
 get_permanent_mac_address()
 {
     $(opt_parse ifname)
 
     if os Linux; then
-        if [[ -e ${EBASH_SYSFS}/class/net/${ifname}/master ]]; then
-            sed -n "/Slave Interface: ${ifname}/,/^$/p" /proc/net/bonding/$(basename $(readlink -f ${EBASH_SYSFS}/class/net/${ifname}/master)) \
+        if [[ -e ${__EBASH_SYSFS}/class/net/${ifname}/master ]]; then
+            sed -n "/Slave Interface: ${ifname}/,/^$/p" /proc/net/bonding/$(basename $(readlink -f ${__EBASH_SYSFS}/class/net/${ifname}/master)) \
                 | grep "Permanent HW addr" \
                 | sed -e "s/Permanent HW addr: //"
         else
-            cat ${EBASH_SYSFS}/class/net/${ifname}/address
+            cat ${__EBASH_SYSFS}/class/net/${ifname}/address
         fi
     elif command_exists ethtool; then
         ethtool -P "${ifname}" | sed -e 's|Permanent address: ||'
@@ -298,7 +298,7 @@ get_network_pci_device()
 
     # If that did not give a result (HyperV), fall back to looking at the device path in sysfs
     if [[ -z ${pci_addr} ]]; then
-        pci_addr=$(cd ${EBASH_SYSFS}/class/net/${ifname}/device; basename $(pwd -P))
+        pci_addr=$(cd ${__EBASH_SYSFS}/class/net/${ifname}/device; basename $(pwd -P))
     fi
 
     echo ${pci_addr}

--- a/share/network.sh
+++ b/share/network.sh
@@ -8,7 +8,7 @@
 # version.
 
 # Set root of sysfs tree for easier mockability in unit tests
-SYSFS="/sys"
+: ${EBASH_SYSFS:=/sys}
 
 opt_usage valid_ip <<'END'
 Check if a given input is a syntactically valid IP Address.
@@ -209,9 +209,9 @@ get_network_interfaces()
         networksetup -listallhardwareports | awk '/Hardware Port: Wi-Fi/{getline; print $2}'
     fi
 
-    for iface in $(ls -1 ${SYSFS}/class/net); do
+    for iface in $(ls -1 ${EBASH_SYSFS}/class/net); do
         # Skip virtual devices, we only want physical
-        [[ ! -e ${SYSFS}/class/net/${iface}/device ]] && continue
+        [[ ! -e ${EBASH_SYSFS}/class/net/${iface}/device ]] && continue
         echo "${iface}"
     done | tr '\n' ' ' || true
 }
@@ -257,20 +257,20 @@ opt_usage get_permanent_mac_address <<'END'
 Get the permanent MAC address for given ifname.
 
 > **_NOTE:_** `ethtool -P` is not reliable on all cards since the firmware has to support it properly. So on Linux we
-instead look in SYSFS since this is far more reliable as we're talking direct to the kernel. But on OSX we instead just
-use ethtool.
+instead look in EBASH_SYSFS since this is far more reliable as we're talking direct to the kernel. But on OSX we instead
+just use ethtool.
 END
 get_permanent_mac_address()
 {
     $(opt_parse ifname)
 
     if os Linux; then
-        if [[ -e ${SYSFS}/class/net/${ifname}/master ]]; then
-            sed -n "/Slave Interface: ${ifname}/,/^$/p" /proc/net/bonding/$(basename $(readlink -f ${SYSFS}/class/net/${ifname}/master)) \
+        if [[ -e ${EBASH_SYSFS}/class/net/${ifname}/master ]]; then
+            sed -n "/Slave Interface: ${ifname}/,/^$/p" /proc/net/bonding/$(basename $(readlink -f ${EBASH_SYSFS}/class/net/${ifname}/master)) \
                 | grep "Permanent HW addr" \
                 | sed -e "s/Permanent HW addr: //"
         else
-            cat ${SYSFS}/class/net/${ifname}/address
+            cat ${EBASH_SYSFS}/class/net/${ifname}/address
         fi
     elif command_exists ethtool; then
         ethtool -P "${ifname}" | sed -e 's|Permanent address: ||'
@@ -298,7 +298,7 @@ get_network_pci_device()
 
     # If that did not give a result (HyperV), fall back to looking at the device path in sysfs
     if [[ -z ${pci_addr} ]]; then
-        pci_addr=$(cd ${SYSFS}/class/net/${ifname}/device; basename $(pwd -P))
+        pci_addr=$(cd ${EBASH_SYSFS}/class/net/${ifname}/device; basename $(pwd -P))
     fi
 
     echo ${pci_addr}

--- a/share/opt.sh
+++ b/share/opt.sh
@@ -727,13 +727,13 @@ opt_display_usage()
 
         # Sort option keys so we can display options in sorted order.
         local opt_keys=()
-        opt_keys=( $(echo ${!__EBASH_OPT[@]} | tr ' ' '\n' | sort) )
+        opt_keys=( $(echo "${!__EBASH_OPT[@]}" | tr ' ' '\n' | sort) )
 
         # Display any REQUIRED options
         local opt
         local required_opts=()
         local entry
-        for opt in ${opt_keys[@]:-}; do
+        for opt in "${opt_keys[@]:-}"; do
 
             if [[ ${__EBASH_OPT_TYPE[$opt]} != "required_string" ]]; then
                 continue
@@ -763,14 +763,14 @@ opt_display_usage()
         done
 
         if [[ "${#required_opts[@]}" -gt 0 ]]; then
-            echo -n "(${required_opts[@]}) "
+            echo -n "(${required_opts[*]}) "
         fi
 
         [[ ${#__EBASH_OPT[@]} -gt 0 ]] && echo -n "[option]... "
 
         # List arguments on the first line
         local i
-        for i in ${!__EBASH_ARG_NAMES[@]} ; do
+        for i in "${!__EBASH_ARG_NAMES[@]}"; do
 
             # Display name of the argument with brackets around it if it is optional
             [[ -n ${__EBASH_ARG_REQUIRED[$i]} ]] || echo -n "["
@@ -806,7 +806,7 @@ opt_display_usage()
             echo "$(ecolor ${COLOR_USAGE})(&) Denotes options which can be given multiple times$(ecolor none)"
             echo
             local opt
-            for opt in ${opt_keys[@]}; do
+            for opt in "${opt_keys[@]}"; do
 
                 # Print the names of all option "synonyms" next to each other
                 echo -n "$(ecolor ${COLOR_USAGE})"
@@ -1064,7 +1064,11 @@ END
 argcheck()
 {
     local _argcheck_arg
-    for _argcheck_arg in $@; do
+    for _argcheck_arg in "$@"; do
+        if [[ -z "${_argcheck_arg}" ]]; then
+            continue
+        fi
+
         if [[ -z "${!_argcheck_arg:-}" ]]; then
             eerror "Missing argument '${_argcheck_arg}'"
             return 1

--- a/share/opt.sh
+++ b/share/opt.sh
@@ -727,13 +727,13 @@ opt_display_usage()
 
         # Sort option keys so we can display options in sorted order.
         local opt_keys=()
-        opt_keys=( $(echo "${!__EBASH_OPT[@]}" | tr ' ' '\n' | sort) )
+        opt_keys=( $(echo ${!__EBASH_OPT[*]} | tr ' ' '\n' | sort) )
 
         # Display any REQUIRED options
         local opt
         local required_opts=()
         local entry
-        for opt in "${opt_keys[@]:-}"; do
+        for opt in ${opt_keys[*]:-}; do
 
             if [[ ${__EBASH_OPT_TYPE[$opt]} != "required_string" ]]; then
                 continue
@@ -770,7 +770,7 @@ opt_display_usage()
 
         # List arguments on the first line
         local i
-        for i in "${!__EBASH_ARG_NAMES[@]}"; do
+        for i in ${!__EBASH_ARG_NAMES[*]} ; do
 
             # Display name of the argument with brackets around it if it is optional
             [[ -n ${__EBASH_ARG_REQUIRED[$i]} ]] || echo -n "["
@@ -806,7 +806,7 @@ opt_display_usage()
             echo "$(ecolor ${COLOR_USAGE})(&) Denotes options which can be given multiple times$(ecolor none)"
             echo
             local opt
-            for opt in "${opt_keys[@]}"; do
+            for opt in ${opt_keys[*]}; do
 
                 # Print the names of all option "synonyms" next to each other
                 echo -n "$(ecolor ${COLOR_USAGE})"

--- a/share/opt.sh
+++ b/share/opt.sh
@@ -311,7 +311,7 @@ opt_parse()
     echo 'argcheck "${__EBASH_ARG_REQUIRED[@]:-}" ; '
 
     # Make sure $@ is filled with args that weren't already consumed
-    echo 'if [[ BASH_VERSINFO[0] -eq 4 && BASH_VERSINFO[1] -eq 2 && ${#__EBASH_ARGS[@]:-} -gt 0 || -v __EBASH_ARGS[@] ]] ; then'
+    echo 'if [[ ${BASH_VERSINFO[0]} -eq 4 && ${BASH_VERSINFO[1]} -eq 2 && ${#__EBASH_ARGS[@]:-} -gt 0 || -v __EBASH_ARGS[@] ]] ; then'
     echo '    set -- "${__EBASH_ARGS[@]}" ; '
     echo 'else '
     echo '    set -- ; '
@@ -488,7 +488,7 @@ opt_parse_options()
 {
     # Odd idiom here to determine if there are no options because of bash 4.2/4.3/4.4 changing behavior. See array_size
     # in array.sh for more info.
-    if [[ BASH_VERSINFO[0] -eq 4 && BASH_VERSINFO[1] -eq 2 ]] ; then
+    if [[ ${BASH_VERSINFO[0]} -eq 4 && ${BASH_VERSINFO[1]} -eq 2 ]] ; then
 
         if [[ ${#__EBASH_FULL_ARGS[@]:-} -eq 0 ]] ; then
             return 0
@@ -678,7 +678,7 @@ opt_parse_options()
     #
     # Odd idiom here to determine if this array contains anything because of bash 4.2/4.3/4.4 changing behavior. See
     # array_size in array.sh for more info.
-    if [[ BASH_VERSINFO[0] -eq 4 && BASH_VERSINFO[1] -eq 2 && ${#__EBASH_ARGS[@]:-} -gt 0 || -v __EBASH_ARGS[@] ]] ; then
+    if [[ ${BASH_VERSINFO[0]} -eq 4 && ${BASH_VERSINFO[1]} -eq 2 && ${#__EBASH_ARGS[@]:-} -gt 0 || -v __EBASH_ARGS[@] ]] ; then
         __EBASH_ARGS=( "${__EBASH_ARGS[@]:$shift_count}" )
     fi
 }

--- a/share/pack.sh
+++ b/share/pack.sh
@@ -90,7 +90,7 @@ pack_get()
 
 pack_contains()
 {
-    [[ -n $(pack_get $@) ]]
+    [[ -n $(pack_get "$@") ]]
 }
 
 opt_usage pack_copy <<'END'

--- a/share/pkg.sh
+++ b/share/pkg.sh
@@ -372,7 +372,7 @@ pkg_upgrade()
     $(opt_parse \
         "@names | Names of the packages that should be upgraded to the newest possible versions.")
 
-    pkg_installed ${names[@]}
+    pkg_installed "${names[@]}"
 
     einfo "Upgrading packages $(lval names)"
 

--- a/share/process.sh
+++ b/share/process.sh
@@ -62,7 +62,7 @@ process_tree()
     fi
 
     local parent children child
-    for parent in ${@} ; do
+    for parent in "${@}"; do
 
         children=$(process_children --ps-all "${ps_all}" ${parent})
         for child in ${children} ; do
@@ -140,7 +140,7 @@ process_parent_tree()
     done
 
     local indent="" link=""
-    for link in ${chain[@]} ; do
+    for link in "${chain[@]}"; do
         echo "$(printf "(%5d)" ${link})${indent}* $(ps ${format} ${link})"
         indent+=" "
     done
@@ -202,7 +202,7 @@ ekill()
     fi
 
     # Kill all requested PIDs using requested signal.
-    kill -${signal} ${processes[@]} &>/dev/null || true
+    kill -${signal} "${processes[@]}" &>/dev/null || true
 
     if [[ -n ${kill_after} && $(signame ${signal}) != "KILL" ]] ; then
         # Note: double fork here in order to keep ekilltree from paying any attention to these processes.
@@ -214,7 +214,7 @@ ekill()
 
                 sleep ${kill_after}
 
-                kill -SIGKILL ${processes[@]} &>/dev/null || true
+                kill -SIGKILL "${processes[@]}" &>/dev/null || true
             ) &
         ) &
     fi
@@ -243,7 +243,7 @@ ekilltree()
     local excluded="" processes=()
 
     excluded="$(process_ancestors ${BASHPID}) ${exclude}"
-    processes=( $(process_tree ${pids[@]:-}) )
+    processes=( $(process_tree "${pids[@]:-}") )
     array_remove -a processes ${excluded}
 
     edebug "Killing $(lval processes signal kill_after excluded)"
@@ -256,7 +256,7 @@ ekilltree()
     # processes get killed and we need to honor the tree ordering of the processes so that we kill the leaf nodes first
     # and walk up the tree.
     local pid
-    for pid in ${processes[@]}; do
+    for pid in "${processes[@]}"; do
         edebug "Killing $(lval pid) of $(lval processes)"
         ekill -s=${signal} -k=${kill_after} ${pid}
     done

--- a/share/testutil.sh
+++ b/share/testutil.sh
@@ -24,5 +24,5 @@ $(skip_if "os_distro centos && os_release 8")
 END
 skip_if()
 {
-    echo "eval if ${@}; then ewarn \"Skipping ${FUNCNAME[1]} because '${@}'\"; return 0; fi"
+    echo "eval if \"${*}\"; then ewarn \"Skipping ${FUNCNAME[1]} because '${*}'\"; return 0; fi"
 }

--- a/share/testutil.sh
+++ b/share/testutil.sh
@@ -24,5 +24,7 @@ $(skip_if "os_distro centos && os_release 8")
 END
 skip_if()
 {
-    echo "eval if \"${*}\"; then ewarn \"Skipping ${FUNCNAME[1]} because '${*}'\"; return 0; fi"
+    # shellcheck disable=SC2145
+    # We do not want to use $* as that doesn't preserve word splitting that we want to honor
+    echo "eval if ${@}; then ewarn \"Skipping ${FUNCNAME[1]} because '${@}'\"; return 0; fi"
 }

--- a/share/try_catch.sh
+++ b/share/try_catch.sh
@@ -178,7 +178,7 @@ tryrc()
     local actual_rc=0
     try
     {
-        if [[ -n "${cmd[@]:-}" ]]; then
+        if [[ -n "${cmd[*]:-}" ]]; then
 
             # Redirect subshell's STDOUT and STDERR to requested locations
             exec >${stdout_file}

--- a/share/type.sh
+++ b/share/type.sh
@@ -105,7 +105,7 @@ END
 is_function()
 {
     if [[ $# != 1 ]] ; then
-        die "is_function takes only a single argument but was passed $@"
+        die "is_function takes only a single argument but was passed $*"
     fi
 
     declare -F "$1" &>/dev/null

--- a/tests/all_depends.etest
+++ b/tests/all_depends.etest
@@ -58,7 +58,7 @@ ETEST_depends()
         "tput"
     )
 
-    assert_commands_installed ${commands[@]}
+    assert_commands_installed "${commands[@]}"
 }
 
 ETEST_recommends()
@@ -81,6 +81,7 @@ ETEST_recommends()
         "pgrep"
         "ping"
         "pstree"
+        "shellcheck"
         "tar"
     )
 
@@ -94,5 +95,5 @@ ETEST_recommends()
         )
     fi
 
-    assert_commands_installed ${commands[@]}
+    assert_commands_installed "${commands[@]}"
 }

--- a/tests/archive.etest
+++ b/tests/archive.etest
@@ -79,7 +79,7 @@ test_all_archives()
     done
 
     eprogress "Waiting"
-    wait ${pids[@]}
+    wait "${pids[@]}"
     eprogress_kill
 
     local rc=0 idx_rc=0 ftype=""
@@ -768,7 +768,7 @@ ETEST_archive_create_pivot_root_multi()
 
         KEEP_PATHS=( /boot /var )
         etestmsg "Creating ${oldroot}/var/log/sfbackup.${ftype}"
-        archive_create -d="${oldroot}" ${oldroot}/var/log/sfbackup.${ftype} ${KEEP_PATHS[@]##/}
+        archive_create -d="${oldroot}" ${oldroot}/var/log/sfbackup.${ftype} "${KEEP_PATHS[@]##/}"
 
         assert_archive_contents ${oldroot}/var/log/sfbackup.${ftype} \
             boot                                    \
@@ -807,7 +807,7 @@ ETEST_archive_create_pivot_root_multi_cd_manual()
         etestmsg "Creating ${oldroot}/var/log/sfbackup.${ftype}"
         (
             cd ${oldroot}
-            archive_create ${oldroot}/var/log/sfbackup.${ftype} ${KEEP_PATHS[@]##/}
+            archive_create ${oldroot}/var/log/sfbackup.${ftype} "${KEEP_PATHS[@]##/}"
         )
 
         assert_archive_contents ${oldroot}/var/log/sfbackup.${ftype} \
@@ -998,13 +998,13 @@ ETEST_archive_extract_pivot_root_multi_deep()
         (
             cd ${oldroot}
             find . -printf '%P\n'
-            archive_create ${oldroot}/var/log/sfbackup.${ftype} ${KEEP_PATHS[@]##/}
+            archive_create ${oldroot}/var/log/sfbackup.${ftype} "${KEEP_PATHS[@]##/}"
         )
-        assert_archive_contents ${oldroot}/var/log/sfbackup.${ftype} ${expect[@]}
+        assert_archive_contents ${oldroot}/var/log/sfbackup.${ftype} "${expect[@]}"
 
         etestmsg "Extracting"
-        archive_extract ${oldroot}/var/log/sfbackup.${ftype} restore ${KEEP_PATHS[@]##/}
-        assert_directory_contents restore ${expect[@]}
+        archive_extract ${oldroot}/var/log/sfbackup.${ftype} restore "${KEEP_PATHS[@]##/}"
+        assert_directory_contents restore "${expect[@]}"
     }
 
     test_all_archives test_body
@@ -1470,7 +1470,7 @@ ETEST_archive_xconvert()
         archive_create src.${ftype} src
 
         local other src_contents cpy_contents src_contents_join cpy_contents_join
-        for other in ${archive_types[@]}; do
+        for other in "${archive_types[@]}"; do
 
             etestmsg "Converting src.${ftype} to cpy.${other}"
             archive_convert src.${ftype} cpy.${other}
@@ -1503,7 +1503,7 @@ ETEST_archive_xdiff()
         archive_create src.${ftype} src
 
         # Iterate over all types and create copy -- diff should match
-        for other in ${archive_types[@]}; do
+        for other in "${archive_types[@]}"; do
 
             etestmsg "Creating cpy.${other}"
             archive_create cpy.${other} src
@@ -1513,7 +1513,7 @@ ETEST_archive_xdiff()
         done
 
         # Iterate over all types and create a different copy with extra file diff should not match.
-        for other in ${archive_types[@]}; do
+        for other in "${archive_types[@]}"; do
 
             etestmsg "Creating diff.${other}"
             efreshdir diff

--- a/tests/cgroup.etest
+++ b/tests/cgroup.etest
@@ -22,26 +22,26 @@ ETEST_cgroup_tree()
 
     etestmsg "Testing full cgroup_tree"
     found_tree=($(cgroup_tree))
-    for item in ${A[@]} ${B[@]} ${C[@]} ; do
+    for item in "${A[@]}" "${B[@]}" "${C[@]}"; do
         assert array_contains found_tree $item
     done
 
 
     etestmsg "Testing that / is the root cgroup_tree"
     found_tree=($(cgroup_tree /))
-    for item in ${A[@]} ${B[@]} ${C[@]} ; do
+    for item in "${A[@]}" "${B[@]}" "${C[@]}"; do
         assert array_contains found_tree $item
     done
 
     etestmsg "Testing cgroup_tree a"
     found_tree=($(cgroup_tree ${CGROUP}/a))
-    for item in ${A[@]} ; do
+    for item in "${A[@]}"; do
         assert array_contains found_tree $item
     done
 
     etestmsg "Testing cgroup_tree with multiple parameters"
     found_tree=($(cgroup_tree ${CGROUP}/b ${CGROUP}/c))
-    for item in ${B[@]} ${C[@]} ; do
+    for item in "${B[@]}" "${C[@]}"; do
         assert array_contains found_tree $item
     done
 }
@@ -103,7 +103,7 @@ ETEST_cgroup_create_destroy()
 
     # Create cgroup and make sure the directories exist in each subsystem
     cgroup_create ${CGROUP}
-    for subsys in ${CGROUP_SUBSYSTEMS[@]} ; do
+    for subsys in "${CGROUP_SUBSYSTEMS[@]}"; do
         assert test -d /sys/fs/cgroup/${subsys}/${CGROUP}
     done
 
@@ -111,7 +111,7 @@ ETEST_cgroup_create_destroy()
 
     # And make sure they get cleaned up
     cgroup_destroy ${CGROUP}
-    for subsys in ${CGROUP_SUBSYSTEMS[@]} ; do
+    for subsys in "${CGROUP_SUBSYSTEMS[@]}"; do
         assert test ! -d /sys/fs/cgroup/${subsys}/${CGROUP}
     done
 }

--- a/tests/chroot.etest
+++ b/tests/chroot.etest
@@ -50,7 +50,7 @@ check_mounts()
     $(opt_parse count)
 
     # Verify chroot paths not mounted
-    for path in "${CHROOT_MOUNTS[@]}"; do
+    for path in ${CHROOT_MOUNTS[@]}; do
 
         if [[ ${count} -eq 0 ]]; then
             assert_false emounted ${CHROOT}${path}
@@ -332,7 +332,7 @@ ETEST_chroot_daemon_bindmount_file()
 
     # Verify mounts are mounted
     etestmsg "Verifying mounts were mounted"
-    for mnt in "${bindmounts[@]}" "${tmpdir1}/YYY"; do
+    for mnt in "${bindmounts[@]} ${tmpdir1}/YYY"; do
         assert_true emounted ${CHROOT}/${mnt}
     done
 
@@ -345,7 +345,7 @@ ETEST_chroot_daemon_bindmount_file()
 
     # Verify mounts are NOT mounted
     etestmsg "Verifying mounts were unmounted"
-    for mnt in "${bindmounts[@]}" "${tmpdir1}/YYY"; do
+    for mnt in "${bindmounts[@]} ${tmpdir1}/YYY"; do
         assert_false emounted ${CHROOT}/${mnt}
     done
 }

--- a/tests/chroot.etest
+++ b/tests/chroot.etest
@@ -50,7 +50,7 @@ check_mounts()
     $(opt_parse count)
 
     # Verify chroot paths not mounted
-    for path in ${CHROOT_MOUNTS[@]}; do
+    for path in "${CHROOT_MOUNTS[@]}"; do
 
         if [[ ${count} -eq 0 ]]; then
             assert_false emounted ${CHROOT}${path}
@@ -332,7 +332,7 @@ ETEST_chroot_daemon_bindmount_file()
 
     # Verify mounts are mounted
     etestmsg "Verifying mounts were mounted"
-    for mnt in "${bindmounts[@]} ${tmpdir1}/YYY"; do
+    for mnt in "${bindmounts[@]}" "${tmpdir1}/YYY"; do
         assert_true emounted ${CHROOT}/${mnt}
     done
 
@@ -345,7 +345,7 @@ ETEST_chroot_daemon_bindmount_file()
 
     # Verify mounts are NOT mounted
     etestmsg "Verifying mounts were unmounted"
-    for mnt in "${bindmounts[@]} ${tmpdir1}/YYY"; do
+    for mnt in "${bindmounts[@]}" "${tmpdir1}/YYY"; do
         assert_false emounted ${CHROOT}/${mnt}
     done
 }

--- a/tests/chroot.etest
+++ b/tests/chroot.etest
@@ -50,7 +50,7 @@ check_mounts()
     $(opt_parse count)
 
     # Verify chroot paths not mounted
-    for path in ${CHROOT_MOUNTS[@]}; do
+    for path in "${CHROOT_MOUNTS[@]}"; do
 
         if [[ ${count} -eq 0 ]]; then
             assert_false emounted ${CHROOT}${path}
@@ -325,6 +325,9 @@ ETEST_chroot_daemon_bindmount_file()
         logfile="${logfile} "                \
         pidfile="${pidfile}"
 
+    etestmsg "Daemon Info"
+    pack_print sleep_daemon
+
     etestmsg "Starting chroot daemon"
     daemon_start sleep_daemon
     daemon_expect pre_start
@@ -332,7 +335,8 @@ ETEST_chroot_daemon_bindmount_file()
 
     # Verify mounts are mounted
     etestmsg "Verifying mounts were mounted"
-    for mnt in "${bindmounts[@]} ${tmpdir1}/YYY"; do
+    for mnt in "${bindmounts[@]}" "${tmpdir1}/YYY"; do
+        einfos "${mnt}"
         assert_true emounted ${CHROOT}/${mnt}
     done
 
@@ -345,7 +349,8 @@ ETEST_chroot_daemon_bindmount_file()
 
     # Verify mounts are NOT mounted
     etestmsg "Verifying mounts were unmounted"
-    for mnt in "${bindmounts[@]} ${tmpdir1}/YYY"; do
+    for mnt in "${bindmounts[@]}" "${tmpdir1}/YYY"; do
+        einfos "${mnt}"
         assert_false emounted ${CHROOT}/${mnt}
     done
 }

--- a/tests/daemon.etest
+++ b/tests/daemon.etest
@@ -127,7 +127,7 @@ netns_add_iptables_rules()
     $(pack_import ${netns_args_packname} ns_name connected_nic)
 
     local device
-    for device in ${ns_name}_br ${connected_nic} ${@} ; do
+    for device in "${ns_name}_br" "${connected_nic}" "${@}"; do
         $(tryrc netns_iptables_rule_exists ${netns_args_packname} ${device})
         [[ ${rc} -eq 0 ]] && continue
         iptables -t nat -A POSTROUTING -o ${device} -j MASQUERADE
@@ -147,7 +147,7 @@ netns_remove_iptables_rules()
     $(pack_import ${netns_args_packname} ns_name connected_nic)
 
     local device
-    for device in ${ns_name}_br ${connected_nic} ${@} ; do
+    for device in "${ns_name}_br" "${connected_nic}" "${@}"; do
         $(tryrc netns_iptables_rule_exists ${netns_args_packname} ${device})
         [[ ${rc} -ne 0 ]] && continue
         iptables -t nat -D POSTROUTING -o ${device} -j MASQUERADE

--- a/tests/dialog.etest
+++ b/tests/dialog.etest
@@ -51,7 +51,7 @@ ETEST_dialog_keys()
     )
 
     etestmsg "Displaying keys"
-    for key in ${keys[@]}; do
+    for key in "${keys[@]}"; do
         einfo "${key}="$(echo "${!key}" | cat -evt)""
     done
 }

--- a/tests/docker.etest
+++ b/tests/docker.etest
@@ -15,12 +15,12 @@ docker_tags_pushed=()
 docker()
 {
     if [[ "${1}" == "push" ]]; then
-        etestmsg "Simulating docker push tags=${@}"
+        etestmsg "Simulating docker push tags=${*}"
         shift
         docker_tags_pushed+=( "${@}" )
         return 0
     elif [[ "${1}" == "login" ]]; then
-        etestmsg "Simulated docker login with args=${@}"
+        etestmsg "Simulated docker login with args=${*}"
         return 0
     fi
 
@@ -364,7 +364,7 @@ ETEST_docker_build_tags()
     assert_docker_image_exists "${image}"
 
     etestmsg "Validating all tags were built"
-    for tag in ${tags[@]}; do
+    for tag in "${tags[@]}"; do
         echo "${tag}"
         assert_docker_image_exists "${tag}"
     done
@@ -412,7 +412,7 @@ ETEST_docker_build_tags_push()
     assert_docker_image_exists "${image}"
 
     etestmsg "Validating all tags were built"
-    for tag in ${tags[@]}; do
+    for tag in "${tags[@]}"; do
         echo "${tag}"
         assert_docker_image_exists "${tag}"
     done
@@ -421,7 +421,7 @@ ETEST_docker_build_tags_push()
     array_sort tags
     array_sort docker_tags_pushed
     etestmsg "$(lval tags docker_tags_pushed)"
-    for tag in ${tags[@]}; do
+    for tag in "${tags[@]}"; do
         array_contains docker_tags_pushed "${tag}"
     done
 }
@@ -640,7 +640,7 @@ ETEST_docker_build_overlay()
         "/usr/local/bin/timedatectl"
     )
 
-    for entry in ${validate_paths[@]}; do
+    for entry in "${validate_paths[@]}"; do
         echo "${entry}"
         docker exec "${container_id}" bash -c "[[ -e ${entry} ]]"
     done
@@ -786,7 +786,7 @@ ETEST_docker_depends_sha()
     find ".work/docker/ebash/overlay"
 
     expect=()
-    for depend in ${depends[@]}; do
+    for depend in "${depends[@]}"; do
         expect+=( "${depend}@sha256:$(sha256sum "${depend}" | awk '{print $1}')" )
     done
 
@@ -864,7 +864,7 @@ ETEST_docker_depends_sha_exclude()
     find ".work/docker/ebash/overlay"
 
     expect=()
-    for depend in ${depends[@]}; do
+    for depend in "${depends[@]}"; do
         expect+=( "${depend}@sha256:$(sha256sum "${depend}" | awk '{print $1}')" )
     done
 

--- a/tests/ebash_interpreter
+++ b/tests/ebash_interpreter
@@ -1,4 +1,5 @@
 #!/usr/bin/env ../../../bin/ebash
+# shellcheck shell=bash
 #
 # Copyright 2020, Marshall McMullen <marshall.mcmullen@gmail.com>
 #

--- a/tests/emsg.etest
+++ b/tests/emsg.etest
@@ -130,7 +130,7 @@ ETEST_ecolor_chart()
     padlength=20
     line=0
 
-    for c in ${ETEST_COLORS[@]}; do
+    for c in "${ETEST_COLORS[@]}"; do
         printf "%s%*.*s" "$(ecolor $c)${c}$(ecolor none)" 0 $((padlength - ${#c} )) "${pad}"
         (( ++line % 8 == 0 )) && printf "\n" || true
 

--- a/tests/hardware.etest
+++ b/tests/hardware.etest
@@ -185,7 +185,7 @@ ETEST_get_memory_invalid_units()
         zap
     )
 
-    for arg in ${invalid[@]}; do
+    for arg in "${invalid[@]}"; do
         echo "${arg}"
         assert_false get_memory_size --unites=${arg}
     done

--- a/tests/netns.etest
+++ b/tests/netns.etest
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2011-2018, Marshall McMullen <marshall.mcmullen@gmail.com> 
+# Copyright 2011-2018, Marshall McMullen <marshall.mcmullen@gmail.com>
 # Copyright 2011-2018, SolidFire, Inc. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify it under the terms of the Apache License
@@ -75,7 +75,7 @@ ETEST_netns_list()
     done
 
     # Verify each namespace shows up in the list
-    for name in ${NS_NAMES[@]}; do
+    for name in "${NS_NAMES[@]}"; do
         echo $(netns_list) | assert grep -q ${name}
     done
 }

--- a/tests/network.etest
+++ b/tests/network.etest
@@ -11,18 +11,18 @@
 # may not have actual sysfs tree.
 setup()
 {
-    EBASH_SYSFS="${TEST_DIR_OUTPUT}/sys"
+    __EBASH_SYSFS="${TEST_DIR_OUTPUT}/sys"
 
-    etestmsg "Creating mock network interfaces in ${EBASH_SYSFS}"
+    etestmsg "Creating mock network interfaces in ${__EBASH_SYSFS}"
 
     for ifname in eth0 eth1; do
         local ifdir
-        ifdir="${EBASH_SYSFS}/class/net/${ifname}"
+        ifdir="${__EBASH_SYSFS}/class/net/${ifname}"
         mkdir -p "${ifdir}/device"
         echo "a8:7e:ea:5d:e4:bd" > "${ifdir}/address"
     done
 
-    find "${EBASH_SYSFS}"
+    find "${__EBASH_SYSFS}"
 }
 
 ETEST_fully_qualify_hostname_ignores_case()

--- a/tests/network.etest
+++ b/tests/network.etest
@@ -7,22 +7,22 @@
 # as published by the Apache Software Foundation, either version 2 of the License, or (at your option) any later
 # version.
 
-# Setup code mocks out some fake paths beneath a fake SYSFS tree for consistent testing even in Docker where we may not
-# have actual sysfs tree.
+# Setup code mocks out some fake paths beneath a fake EBASH_SYSFS tree for consistent testing even in Docker where we
+# may not have actual sysfs tree.
 setup()
 {
-    SYSFS="${TEST_DIR_OUTPUT}/sys"
+    EBASH_SYSFS="${TEST_DIR_OUTPUT}/sys"
 
-    etestmsg "Creating mock network interfaces in ${SYSFS}"
+    etestmsg "Creating mock network interfaces in ${EBASH_SYSFS}"
 
     for ifname in eth0 eth1; do
         local ifdir
-        ifdir="${SYSFS}/class/net/${ifname}"
+        ifdir="${EBASH_SYSFS}/class/net/${ifname}"
         mkdir -p "${ifdir}/device"
         echo "a8:7e:ea:5d:e4:bd" > "${ifdir}/address"
     done
 
-    find "${SYSFS}"
+    find "${EBASH_SYSFS}"
 }
 
 ETEST_fully_qualify_hostname_ignores_case()

--- a/tests/opt.etest
+++ b/tests/opt.etest
@@ -674,7 +674,7 @@ ETEST_opt_forward_different_name()
 
     subfunc()
     {
-        einfo "ARGS=${@}"
+        einfo "ARGS=${*}"
         $(opt_parse ":altname")
 
         assert_eq "${altname}" "${OPTION}"

--- a/tests/pack.etest
+++ b/tests/pack.etest
@@ -198,7 +198,7 @@ ETEST_pack_update_updates_values()
 ETEST_pack_avoid_common_variable_conflicts()
 {
     POTENTIAL_VARS=(arg val key tag)
-    for VAR in ${POTENTIAL_VARS[@]} ; do
+    for VAR in "${POTENTIAL_VARS[@]}"; do
         einfo "Testing for conflicts in variable name ${VAR}"
 
         pack_set ${VAR} a=1 b=2 c=3

--- a/tests/pkg.etest
+++ b/tests/pkg.etest
@@ -16,7 +16,7 @@ setup()
 
     # Find package we can install from pkg_candidates
     local pkg="" found=0
-    for pkg in ${pkg_candidates[@]}; do
+    for pkg in "${pkg_candidates[@]}"; do
         etestmsg "Checking $(lval pkg pkg_candidates)"
         if pkg_known ${pkg} && ! pkg_installed ${pkg}; then
             found=1

--- a/tests/process.etest
+++ b/tests/process.etest
@@ -72,13 +72,13 @@ ETEST_process_hierarchy()
     # Note: there will be ancestors in the list that I don't know about (for instance, the etest processes), but I know
     # that the processes I created and added to pids should be in there.
     local process
-    for process in ${my_processes[@]} ; do
+    for process in "${my_processes[@]}"; do
         assert array_contains ancestors ${process}
         assert array_contains ancestors_noarg ${process}
     done
 
     etestmsg "Verifying tree contains my processes $(lval tree my_processes)"
-    for process in ${my_processes[@]} ; do
+    for process in "${my_processes[@]}"; do
         assert array_contains tree ${process}
     done
 }
@@ -138,10 +138,10 @@ ETEST_ekill_multiple()
     local pids
     pids=( $(cat pids) )
     etestmsg "Killing all $(lval pids)"
-    ekill ${pids[@]}
+    ekill "${pids[@]}"
 
     etestmsg "Waiting for $(lval pid pids SECONDS)"
-    eretry -t=2s -T=20s process_not_running ${pids[@]}
+    eretry -t=2s -T=20s process_not_running "${pids[@]}"
 }
 
 ETEST_ekilltree()
@@ -175,7 +175,7 @@ ETEST_ekilltree()
 
     etestmsg "After killing $(lval main_pid) -- Expected death from $(lval pids) -- My $(lval BASHPID)"
     pstree -c $$
-    eretry --timeout 5s process_not_running ${pids[@]}
+    eretry --timeout 5s process_not_running "${pids[@]}"
 }
 
 ETEST_ekilltree_excludes_self()


### PR DESCRIPTION
This adds https://www.shellcheck.net/ support into ebash provided bashlint/elint. There are new flags in bashlint specifically to make this easier:

```
--shellcheck-errors / --errors
--shellcheck-warnings / --warnings
--shellcheck-info / --info
--shellcheck-style / --style
```

Also fixed ALL the errors identified by shellcheck in ebash itself.
