### PR TITLE
Add enabled support to daemon module and systemctl wrapper.

### DIFF
--- a/share/docker-overlay/systemd/usr/local/bin/systemctl
+++ b/share/docker-overlay/systemd/usr/local/bin/systemctl
@@ -3,12 +3,25 @@
 $(ebash --source)
 
 $(opt_parse \
-    "action  | The action to perform (start, stop, status, restart, is-active)." \
-    "service | The service to perform action on (e.g. sshd)."                    \
+    "+verbose v | Be more verbose and show detailed errors and stacktraces."                                           \
+    "action     | The action to perform (start, stop, status, restart, is-active)."                                    \
+    "service    | The service to perform action on (e.g. sshd)."                                                       \
 )
 
 # Disable stacktraces emitted by ebash die() as we do not want them to perculate out to the user from this wrapper.
-disable_die_stacktrace
+if [[ ${verbose} -eq 0 ]]; then
+    disable_die_stacktrace
+fi
+
+# If the action is 'enable' or 'disable' then there may be an optional '--now' option immediately after it.
+now="0"
+if [[ "${action}" == @(enable|disable) && "${service}" == "--now" ]]; then
+    now=1
+    service=$1
+    shift
+fi
+
+edebug "$(lval verbose action service now)"
 
 # Get the configuration file for the requested service.
 cfgfile="${__EBASH_DAEMON_RUNDIR}/${service}"
@@ -19,25 +32,52 @@ fi
 # Load ebash daemon configuration for this service.
 pack_load cfg "${cfgfile}"
 edebug "Loaded daemon $(lval %cfg)"
+if [[ ${verbose} -eq 1 ]]; then
+    einfo "Loaded daemon $(lval %cfg)"
+fi
 
 # Perform the requested action using ebash provided daemon functions.
 case ${action} in
     start)
         daemon_start cfg
-    ;;
+        ;;
+
     stop)
         daemon_stop cfg
-    ;;
+        ;;
+
     status)
         daemon_status cfg
-    ;;
+        ;;
+
     restart)
         daemon_restart cfg
-    ;;
+        ;;
+
     is-active)
         daemon_running cfg
-    ;;
+        ;;
+
+    is-enabled)
+        daemon_enabled cfg
+        ;;
+
+    enable)
+        daemon_enable cfg
+        if [[ "${now}" -eq 1 ]]; then
+            daemon_start cfg
+        fi
+        ;;
+
+    disable)
+        daemon_disable cfg
+        if [[ "${now}" -eq 1 ]]; then
+            daemon_stop cfg
+        fi
+
+        ;;
+
     *)
         die "Unsupported $(lval action)"
-    ;;
+        ;;
 esac

--- a/tests/daemon.etest
+++ b/tests/daemon.etest
@@ -211,6 +211,7 @@ ETEST_daemon_init()
     assert_eq "Init Test Daemon" "${name}"
     assert_eq "sleep infinity"   "${cmdline}"
     assert_eq "${FUNCNAME}.pid"  "${pidfile}"
+    assert_eq "true" "${enabled}"
 }
 
 ETEST_daemon_autostart()
@@ -339,6 +340,81 @@ ETEST_daemon_start_stop_start()
     assert daemon_status  sleep_daemon
 
     # Now stop it and verify proper shutdown
+    local pid
+    pid=$(cat "${pidfile}")
+    daemon_stop sleep_daemon &
+    daemon_expect pre_stop
+    daemon_expect post_stop
+    wait
+    assert_false daemon_running sleep_daemon
+    assert_false daemon_status -q sleep_daemon
+    assert_not_exists pidfile
+}
+
+ETEST_daemon_enabled()
+{
+    local pidfile="${FUNCNAME}.pid"
+    local cfgfile="${FUNCNAME}.cfg"
+    local sleep_daemon
+
+    etestmsg "Initializing infinity daemon"
+    daemon_init sleep_daemon            \
+        "${DAEMON_EXPECT[@]}"           \
+        name="Test Daemon"              \
+        cmdline="sleep infinity"        \
+        pidfile="${pidfile}"            \
+        cfgfile="${cfgfile}"
+
+    $(pack_import sleep_daemon)
+    etestmsg "Verifying daemon $(lval %sleep_daemon)"
+    daemon_enabled sleep_daemon
+
+    etestmsg "Disabling daemon"
+    daemon_disable sleep_daemon
+    assert_false daemon_enabled sleep_daemon
+
+    etestmsg "Enabling daemon"
+    daemon_enable sleep_daemon
+    daemon_enabled sleep_daemon
+}
+
+# Make sure you can still start/stop a disabled daemon as these are orthogonal concepts.
+ETEST_daemon_disable_start()
+{
+    local pidfile="${FUNCNAME}.pid"
+    local cfgfile="${FUNCNAME}.cfg"
+    local sleep_daemon
+
+    etestmsg "Initializing infinity daemon"
+    daemon_init sleep_daemon            \
+        "${DAEMON_EXPECT[@]}"           \
+        name="Test Daemon"              \
+        cmdline="sleep infinity"        \
+        pidfile="${pidfile}"            \
+        cfgfile="${cfgfile}"
+
+    $(pack_import sleep_daemon)
+    etestmsg "Verifying daemon $(lval %sleep_daemon)"
+    daemon_enabled sleep_daemon
+
+    etestmsg "Disabling daemon"
+    daemon_disable sleep_daemon
+    assert_false daemon_enabled sleep_daemon
+
+    etestmsg "Starting daemon"
+    daemon_start sleep_daemon
+
+    etestmsg "Waiting for daemon to be running"
+    daemon_expect pre_start
+    daemon_expect post_mount
+    assert_true daemon_running sleep_daemon
+    assert test -s ${pidfile}
+    assert test -s ${cfgfile}
+    assert process_running $(cat ${pidfile})
+    assert daemon_running sleep_daemon
+    assert daemon_status  sleep_daemon
+
+    etestmsg "Verying we can stop a disabled daemon"
     local pid
     pid=$(cat "${pidfile}")
     daemon_stop sleep_daemon &

--- a/tests/docker.etest
+++ b/tests/docker.etest
@@ -729,6 +729,78 @@ ETEST_docker_build_overlay_systemctl_wrapper()
     eretry --max-timeout 30s docker exec "${container_id}" systemctl status sleeper2
 }
 
+ETEST_docker_build_overlay_systemctl_wrapper_enabled()
+{
+    # For no explicable reason, this test is very flaky on Centos:8 but perfectly stable on all other distros.
+    $(skip_if "os_distro centos && os_release 8")
+    $(skip_if "os_distro rocky  && os_release 8.4")
+
+    EDEBUG=daemon
+
+    etestmsg "Creating init"
+	cat <<-'END' >init
+	#!/bin/bash
+
+	$(ebash --source)
+
+	EDEBUG=daemon
+
+	# Block all signals that would otherwise cause us to exit similar to real 'init'
+	disable_signals
+
+	daemon_init sleeper1         \
+	    autostart="false"        \
+	    cmdline="sleep infinity" \
+	    enabled="false"
+
+	# Process reaping
+	while true; do
+		wait
+	done
+	END
+    cat init
+    chmod +x init
+
+    etestmsg "Creating Dockerfile"
+	cat <<-END >Dockerfile
+	FROM ubuntu:20.04
+	COPY "init" "/init"
+	ENTRYPOINT ["/init"]
+	END
+    cat Dockerfile
+
+    etestmsg "Building docker image"
+    docker_build \
+        --name "elibs/ebash"                   \
+        --file "${TEST_DIR_OUTPUT}/Dockerfile" \
+        --overlay "ebash"                      \
+        --overlay "systemd"
+    cat ".work/docker/ebash/dockerfile"
+    find ".work/docker/ebash/overlay" -ls
+
+    etestmsg "Running docker container"
+    image="$(cat .work/docker/ebash/image)"
+    container_id=$(docker run --detach --network host "${image}")
+    trap_add "docker kill ${container_id}"
+    eretry --max-timeout 30s docker exec "${container_id}" bash -c "[[ -e /usr/local/bin/systemctl ]]"
+
+    etestmsg "Verifying daemon is not enabled and not running"
+    assert_false docker exec "${container_id}" systemctl status sleeper1
+    assert_false docker exec "${container_id}" systemctl is-active sleeper1
+    assert_false docker exec "${container_id}" systemctl is-enabled sleeper1
+
+    etestmsg "Enable and Start Daemon"
+    docker exec "${container_id}" systemctl enable --now sleeper1
+    docker exec "${container_id}" systemctl is-active sleeper1
+    docker exec "${container_id}" systemctl is-enabled sleeper1
+
+    etestmsg "Disable and Stop Daemon"
+    docker exec "${container_id}" systemctl disable --now sleeper1
+    assert_false docker exec "${container_id}" systemctl status sleeper1
+    assert_false docker exec "${container_id}" systemctl is-active sleeper1
+    assert_false docker exec "${container_id}" systemctl is-enabled sleeper1
+}
+
 ETEST_docker_depends_sha()
 {
     etestmsg "Creating Dockerfile"


### PR DESCRIPTION
This adds support to ebash daemons to mark a daemon as enabled or not. This will allow us to support the systemctl idiom of `systemctl enable --now <service>` and `systemctl disable --now <service>` more naturally. For ebash daemon purposes we're not _really_ making use of this flag. But we're allowing the caller's init script to make use of it. For example, you can send SIGTERM or mock out reboots in a docker container and the init script could then decide to start the daemons or not based on if they are enabled. This is all for the caller to use as they see fit. 