### PR TITLE
Fix trap_add to deal with multiple signals properly and do not register multiple

### DIFF
--- a/tests/trap.etest
+++ b/tests/trap.etest
@@ -30,6 +30,11 @@ ETEST_trap_add_multiple_signals()
             continue
         fi
 
+        # Some signals don't work correctly on Darwin
+        if os darwin && [[ ${sig} == @(SIGPIPE) ]]; then
+            continue
+        fi
+
         assert_eq 'die -s='${sig}' "[Caught '${sig}' pid=${BASHPID} cmd=$(string_truncate -e $(tput cols) ${BASH_COMMAND})"]' "$(trap_get ${sig})"
     done
 
@@ -52,6 +57,12 @@ ETEST_trap_add_defaults()
 
     # Untrapped signals still receive default handling without the 'echo foo' command
     for sig in ${DIE_SIGNALS[*]}; do
+
+        # Some signals don't work correctly on Darwin
+        if os darwin && [[ ${sig} == @(SIGPIPE) ]]; then
+            continue
+        fi
+
         assert_eq 'die -s='${sig}' "[Caught '${sig}' pid=${BASHPID} cmd=$(string_truncate -e $(tput cols) ${BASH_COMMAND})"]' "$(trap_get ${sig})"
     done
 }

--- a/tests/trap.etest
+++ b/tests/trap.etest
@@ -24,7 +24,7 @@ ETEST_trap_add_multiple_signals()
     assert_eq 'echo foo;die -s=SIGUSR1 "[Caught SIGUSR1 pid=${BASHPID} cmd=$(string_truncate -e $(tput cols) ${BASH_COMMAND})"]' "$(trap_get SIGUSR1)"
 
     # Untrapped signals still receive default handling without the 'echo foo' command
-    for sig in ${DIE_SIGNALS[@]}; do
+    for sig in ${DIE_SIGNALS[*]}; do
 
         if [[ "${sig}" == @(SIGHUP|SIGUSR1) ]]; then
             continue
@@ -51,7 +51,7 @@ ETEST_trap_add_defaults()
     assert_eq '_ebash_on_exit_start;echo foo;_ebash_on_exit_end' "$(trap_get EXIT)"
 
     # Untrapped signals still receive default handling without the 'echo foo' command
-    for sig in ${DIE_SIGNALS[@]}; do
+    for sig in ${DIE_SIGNALS[*]}; do
         assert_eq 'die -s='${sig}' "[Caught '${sig}' pid=${BASHPID} cmd=$(string_truncate -e $(tput cols) ${BASH_COMMAND})"]' "$(trap_get ${sig})"
     done
 }

--- a/tests/trap.etest
+++ b/tests/trap.etest
@@ -7,6 +7,55 @@
 # as published by the Apache Software Foundation, either version 2 of the License, or (at your option) any later
 # version.
 
+# Basic trap_add and trap_get sanity test with 1 signal.
+ETEST_trap_add()
+{
+    trap_add 'echo foo' SIGHUP
+    assert_eq 'echo foo;die -s=SIGHUP "[Caught SIGHUP pid=${BASHPID} cmd=$(string_truncate -e $(tput cols) ${BASH_COMMAND})"]' "$(trap_get SIGHUP)"
+}
+
+# Verify a bug is fixed where we were building up a combined trap with the same command multiple times if given an
+# explicit list of signals. This was caused by not initializing the trap on the first time through the for loop inside
+# trap_add.
+ETEST_trap_add_multiple_signals()
+{
+    trap_add 'echo foo' SIGHUP SIGUSR1
+    assert_eq 'echo foo;die -s=SIGHUP "[Caught SIGHUP pid=${BASHPID} cmd=$(string_truncate -e $(tput cols) ${BASH_COMMAND})"]' "$(trap_get SIGHUP)"
+    assert_eq 'echo foo;die -s=SIGUSR1 "[Caught SIGUSR1 pid=${BASHPID} cmd=$(string_truncate -e $(tput cols) ${BASH_COMMAND})"]' "$(trap_get SIGUSR1)"
+
+    # Untrapped signals still receive default handling without the 'echo foo' command
+    for sig in ${DIE_SIGNALS[@]}; do
+
+        if [[ "${sig}" == @(SIGHUP|SIGUSR1) ]]; then
+            continue
+        fi
+
+        assert_eq 'die -s='${sig}' "[Caught '${sig}' pid=${BASHPID} cmd=$(string_truncate -e $(tput cols) ${BASH_COMMAND})"]' "$(trap_get ${sig})"
+    done
+
+}
+
+# Verify implicit ebash traps added for exit to propogate failures to caller properly.
+ETEST_trap_add_exit()
+{
+    trap_add 'echo foo' EXIT SIGHUP SIGUSR1
+    assert_eq '_ebash_on_exit_start;echo foo;_ebash_on_exit_end' "$(trap_get EXIT)"
+    assert_eq 'echo foo;die -s=SIGHUP "[Caught SIGHUP pid=${BASHPID} cmd=$(string_truncate -e $(tput cols) ${BASH_COMMAND})"]' "$(trap_get SIGHUP)"
+    assert_eq 'echo foo;die -s=SIGUSR1 "[Caught SIGUSR1 pid=${BASHPID} cmd=$(string_truncate -e $(tput cols) ${BASH_COMMAND})"]' "$(trap_get SIGUSR1)"
+}
+
+# Verify implicit traps when no signals added
+ETEST_trap_add_defaults()
+{
+    trap_add 'echo foo'
+    assert_eq '_ebash_on_exit_start;echo foo;_ebash_on_exit_end' "$(trap_get EXIT)"
+
+    # Untrapped signals still receive default handling without the 'echo foo' command
+    for sig in ${DIE_SIGNALS[@]}; do
+        assert_eq 'die -s='${sig}' "[Caught '${sig}' pid=${BASHPID} cmd=$(string_truncate -e $(tput cols) ${BASH_COMMAND})"]' "$(trap_get ${sig})"
+    done
+}
+
 ETEST_err_and_debug_traps_are_inherited()
 {
     on_error()


### PR DESCRIPTION
Bo found an issue where if we call `trap_add` with an explicit list of signals it was compounding the command that would get run. e.g. if you ran 

`trap_add "echo foo" SIGUSR1 SIGUSR2` 

then you'd end up executing a command of `echo foo` for `SIGUSR1`. But unexpectedly `echo foo; echo foo` for `SIGUSR2`.

This is because we were not initializing the `complete_trap` variable properly.

I also found sometimes we'd end up with syntax errors in the final command due to silly things like `echo foo; ;` where the second command of `; ;` is not legal bash syntax. Making it an array maid it simpler to manipulate the command we're building up.

Added some new tests to validate the new behavior.

BTW, I started down the path of adding some more powerful `trap_pop` functionality but it got complicated and risky to let the caller pop of error handing code from the stack, so I backed away from that.