### PR TITLE
Go

### DIFF
--- a/install/go
+++ b/install/go
@@ -36,27 +36,30 @@ fi
 if [[ -n "${package}" ]]; then
     pkg_install "${package}"
 elif os linux; then
-    ewarn "Go not available via package manager on $(os_pretty_name)."
-    ewarn "Downloading pre-built package from official Go URL"
 
-    # Temporary file to download to
-    tmpfile=$(mktemp --tmpdir ebash-install-go-XXXXXX)
-    trap_add "rm -f ${tmpfile}"
+    # If we already have Go installed there's nothing to do.
+    if ! which go &>/dev/null; then
+        einfo "Go not available via package manager on $(os_pretty_name). Downloading from official Go URL."
 
-    # Download
-    eretry efetch --style=einfo \
-        "https://dl.google.com/go/$(curl https://golang.org/VERSION?m=text).linux-amd64.tar.gz" "${tmpfile}"
+        # Download
+        version="$(curl --silent --location https://golang.org/VERSION?m=text)"
+        url="https://dl.google.com/go/${version}.linux-amd64.tar.gz"
+        tarball="${TMPDIR:-/tmp}/$(basename "${url}")"
+        eretry efetch --style=einfo "${url}" "${tarball}"
+        trap_add "rm -f ${tarball}"
 
-    mkdir -p "/usr/local/bin"
-    tar --directory "/usr/local" --extract --xz --file "${tmpfile}"
+        # Extract
+        mkdir -p "/usr/local/bin"
+        tar --directory "/usr/local" --extract --gzip --file "${tarball}"
+
+        # Add symlinks to /usr/local/bin
+        einfo "Creating symbolic links for go binaries"
+        ln -sv "/usr/local/go/bin/"* "/usr/local/bin"
+    fi
+
 else
     die "Cannot install Go on $(os_pretty_name)"
 fi
 
-ewarn "Please make sure to update your PATH appropriately so that your shell can find Go"
-ewarn "For example, you probably want to add this to your ~/.bashrc or ~/.zshrc file:"
-ewarn 'export PATH=$PATH:/usr/local/go/bin'
-
 # Verify installation succeeded
-PATH+=:/usr/local/go/bin
 command_exists "go"

--- a/install/go
+++ b/install/go
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Copyright 2021, Marshall McMullen <marshall.mcmullen@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify it under the terms of the Apache License
+# as published by the Apache Software Foundation, either version 2 of the License, or (at your option) any later
+# version.
+
+: ${EBASH_HOME:=$(dirname $0)/..}
+: ${EBASH:=${EBASH_HOME}/share}
+source "${EBASH}/ebash.sh" || { echo "Unable to source ${EBASH}/ebash.sh" ; exit 1 ; }
+
+opt_usage main <<'END'
+This script is used to install Go onto a system. For distros which have a new enough version packaged up in the package
+manager we can simply invoke their installer. Otherwise we install Go from the official upstream tarball.
+END
+
+OS=$(os_pretty_name)
+ebanner --uppercase "Installing Go package" OS
+
+#----------------------------------------------------------------------------------------------------------------------
+#
+# Main
+#
+#----------------------------------------------------------------------------------------------------------------------
+
+# Determine what the name of the package is to install on this OS/Distro (if any).
+package=""
+if os darwin || os_distro alpine arch gentoo; then
+    package="go"
+elif os_distro debian fedora; then
+    package="golang-bin"
+fi
+
+# If a package is available on this OS/distro install it. Otherwise download the package from upstream pre-built binary
+if [[ -n "${package}" ]]; then
+    pkg_install "${package}"
+elif os linux; then
+    ewarn "Go not available via package manager on $(os_pretty_name)."
+    ewarn "Downloading pre-built package from official Go URL"
+
+    # Temporary file to download to
+    tmpfile=$(mktemp --tmpdir ebash-install-go-XXXXXX)
+    trap_add "rm -f ${tmpfile}"
+
+    # Download
+    eretry efetch --style=einfo \
+        "https://dl.google.com/go/$(curl https://golang.org/VERSION?m=text).linux-amd64.tar.gz" "${tmpfile}"
+
+    mkdir -p "/usr/local/bin"
+    tar --directory "/usr/local" --extract --xz --file "${tmpfile}"
+else
+    die "Cannot install Go on $(os_pretty_name)"
+fi
+
+ewarn "Please make sure to update your PATH appropriately so that your shell can find Go"
+ewarn "For example, you probably want to add this to your ~/.bashrc or ~/.zshrc file:"
+ewarn 'export PATH=$PATH:/usr/local/go/bin'
+
+# Verify installation succeeded
+PATH+=:/usr/local/go/bin
+command_exists "go"

--- a/tests/all_depends.etest
+++ b/tests/all_depends.etest
@@ -98,3 +98,16 @@ ETEST_recommends()
 
     assert_commands_installed "${commands[@]}"
 }
+
+ETEST_install_go()
+{
+    local commands=(
+        "go"
+        "gofmt"
+    )
+
+    # Run the install script
+    ${EBASH_HOME}/install/go
+
+    assert_commands_installed "${commands[@]}"
+}


### PR DESCRIPTION
Provide a simple install script to make it easier to install `go` with diverse package naming across distros and lack of packages at all (e.g. on Ubuntu). 