### PR TITLE
Etest pidleak

### DIFF
--- a/bin/etest
+++ b/bin/etest
@@ -230,77 +230,59 @@ die_handler()
     exit ${rc}
 }
 
-# Returns success if there are no stale processes remaining in the cgroup for this test and failure if there are any.
-no_process_leaks_remain()
+assert_no_process_leaks()
 {
     if ! cgroup_supported; then
         return 0
     fi
 
-    # If the cgroup no longer exists, we're in good shape because you can't destroy a cgroup until all its processes are
-    # dead.
-    $(tryrc -r=exists_rc cgroup_exists ${ETEST_CGROUP})
-    if [[ ${exists_rc} -ne 0 ]] ; then
+    edebug "Checking for process leaks in ${ETEST_CGROUP}"
+
+    if ! cgroup_exists "${ETEST_CGROUP}"; then
+        edebug "$(lval ETEST_CGROUP) does not exist -- returning"
         return 0
     fi
 
-    # Get a list of pids in our CGROUP, excluding the elogfile pids as we know they are always going to be running at
-    # this point.
-    #
-    # NOTE: Since we just checked that the cgroup exists, we also know the cgroup_pids will exist, because nothing else
-    #       will destroy the cgroup except for us.
-    local remaining_pids=""
-    remaining_pids=$(cgroup_pids --exclude "$(elogfile_pids)" ${ETEST_CGROUP})
-    etestmsg "$(lval remaining_pids exists_rc ETEST_CGROUP)"
-    [[ -z ${remaining_pids} ]]
-}
-
-assert_no_process_leaks()
-{
-    # Error stacks generated here should produce output, even though etest has them wrapped in a try.
-    __EBASH_INSIDE_TRY=0
-
-    edebug "Waiting..."
+    __check_process_leaks()
+    {
+        [[ -z "$(cgroup_pids "${ETEST_CGROUP}")" ]]
+    }
 
     # Check if any processes leaked. Check quickly to avoid unecessary delays at clean-up time. If there are any
     # leaked processes remaining, THEN do an eretry to give them time to shutdown. Finally, assert that there are none
     # left.
-    $(tryrc no_process_leaks_remain)
-    if [[ ${rc} -ne 0 ]]; then
-        $(tryrc eretry -T=5s no_process_leaks_remain)
-    fi
-
-    # The above command could have timed out but that doesn't necessarily mean there are leaked processes. So KILL
-    # anything that's left, but only DIE if there were actually processes leaked.
-    if [[ ${rc} -ne 0 ]] && cgroup_supported ; then
+    try
+    {
+        eretry -T=5s __check_process_leaks
+    }
+    catch
+    {
         local leaked_processes=""
-        leaked_processes=$(cgroup_ps ${ETEST_CGROUP})
+        leaked_processes=$(cgroup_ps "${ETEST_CGROUP}")
+
         if [[ -n ${leaked_processes} ]]; then
-            cgroup_kill_and_wait -s=SIGKILL ${ETEST_CGROUP}
-
-            die "Leaked processes in ${ETEST_CGROUP}:\n${leaked_processes}"
+            cgroup_kill_and_wait -s=SIGKILL "${ETEST_CGROUP}"
+            eerror "Leaked processes in ${cgroup}:\n${leaked_processes}"
+            return 1
         fi
-    fi
+    }
 
-    edebug "Finished"
+    edebug "Finished checking for process leaks in ${cgroup}"
 }
 
 assert_no_mount_leaks()
 {
-    $(opt_parse path)
-    edebug "Checking for stale mounts under $(lval path)"
-
     local mounts=()
-    mounts=( $(efindmnt "${path}" ) )
+    mounts=( $(efindmnt "${work_dir}" ) )
 
     if ! array_empty mounts; then
-        eunmount --all --recursive --delete=${delete} "${path}"
-        eerror "Leaked under $(lval mounts path)"$'\n'"$(array_join_nl mounts)"
-        die "Leaked mounts"
+        eunmount --all --recursive --delete=${delete} "${work_dir}"
+        eerror "Leaked under $(lval mounts work_dir)"$'\n'"$(array_join_nl mounts)"
+        return 1
     fi
 
     if [[ ${delete} -eq 1 ]]; then
-        rm --recursive --force "${path}"
+        rm --recursive --force "${work_dir}"
     fi
 
     edebug "Finished"
@@ -315,33 +297,33 @@ global_setup()
     # needs and assuming the test succeeds we'll auto remove the directory after the test completes.
     efreshdir "${work_dir}"
 
+    # If cgroups are supported, create a new parent cgroup which will contain all our processes including the elogfile
+    # processes we already launched.
     if cgroup_supported ; then
-        # And a cgroup that will contain all output
         cgroup_create ${ETEST_CGROUP}
-        cgroup_move ${ETEST_CGROUP_BASE} $$
+        cgroup_move ${ETEST_CGROUP_BASE} $$ $(elogfile_pids)
     fi
 
     edebug "Finished global_setup"
-    return 0
 }
 
 global_teardown()
 {
     ecolor show_cursor &>${ETEST_OUT}
 
-    if [[ ${delete} -eq 0 ]]; then
-        edebug "Skipping global_teardown"
-        return 0
-    fi
-
     edebug "Running global_teardown: PID=$$ BASHPID=${BASHPID} PPID=${PPID}"
 
-    assert_no_process_leaks
-    assert_no_mount_leaks ${work_dir}
-
-    if cgroup_supported ; then
-        cgroup_destroy -r ${ETEST_CGROUP}
-    fi
+    # Try to clean up any lingering process leaks or mount leaks but do not fail here as we need to perform additional
+    # cleanup after this.
+    try
+    {
+        assert_no_process_leaks
+        assert_no_mount_leaks
+    }
+    catch
+    {
+        eerror "Unexpected leaked processes or mount leaks in global_teardown"
+    }
 
     # Convert logfile to HTML if requested
     if [[ ${html} -eq 1 ]] && which ansi2html &>/dev/null; then
@@ -350,8 +332,12 @@ global_teardown()
         noansi ${ETEST_LOG}
     fi
 
+    # Destroy parent cgroup
+    if cgroup_supported ; then
+        cgroup_destroy -r ${ETEST_CGROUP_BASE}
+    fi
+
     edebug "Finished global_teardown"
-    return 0
 }
 
 run_single_test()
@@ -487,7 +473,7 @@ run_single_test()
         try
         {
             assert_no_process_leaks
-            assert_no_mount_leaks "${work_dir}"
+            assert_no_mount_leaks
         }
         catch
         {

--- a/bin/etest
+++ b/bin/etest
@@ -243,17 +243,12 @@ assert_no_process_leaks()
         return 0
     fi
 
-    __check_process_leaks()
-    {
-        [[ -z "$(cgroup_pids "${ETEST_CGROUP}")" ]]
-    }
-
     # Check if any processes leaked. Check quickly to avoid unecessary delays at clean-up time. If there are any
     # leaked processes remaining, THEN do an eretry to give them time to shutdown. Finally, assert that there are none
     # left.
     try
     {
-        eretry -T=5s __check_process_leaks
+        eretry -T=5s cgroup_empty "${ETEST_CGROUP}"
     }
     catch
     {
@@ -262,12 +257,12 @@ assert_no_process_leaks()
 
         if [[ -n ${leaked_processes} ]]; then
             cgroup_kill_and_wait -s=SIGKILL "${ETEST_CGROUP}"
-            eerror "Leaked processes in ${cgroup}:\n${leaked_processes}"
+            eerror "Leaked processes in ${ETEST_CGROUP}:\n${leaked_processes}"
             return 1
         fi
     }
 
-    edebug "Finished checking for process leaks in ${cgroup}"
+    edebug "Finished checking for process leaks in ${ETEST_CGROUP}"
 }
 
 assert_no_mount_leaks()
@@ -332,12 +327,15 @@ global_teardown()
         noansi ${ETEST_LOG}
     fi
 
+    edebug "Finished global_teardown"
+
+    # Gracefully stop elogfile
+    elogfile_kill --all
+
     # Destroy parent cgroup
     if cgroup_supported ; then
-        cgroup_destroy -r ${ETEST_CGROUP_BASE}
+        cgroup_destroy --recursive ${ETEST_CGROUP}
     fi
-
-    edebug "Finished global_teardown"
 }
 
 run_single_test()

--- a/share/cgroup.sh
+++ b/share/cgroup.sh
@@ -535,3 +535,23 @@ cgroup_find_setting_file()
     $(opt_parse cgroup setting)
     ls ${CGROUP_SYSFS}/*/${cgroup}/${setting}
 }
+
+opt_usage cgroup_empty <<'END'
+cgroup_empty is a simple wrapper around cgroup_pids. It simply checks if all the provided cgroups are empty or not.
+Which means that there are no pids running in the provided cgroups.
+END
+cgroup_empty()
+{
+    $(opt_parse \
+        ":exclude x   | Space separated list of pids not to return. By default returns all." \
+        "+recursive r | Additionally return pids for processes of this cgroup's children." \
+        "@cgroups     | Cgroups whose processes should be listed.")
+
+    local pids=()
+    pids=( $(opt_forward cgroup_pids exclude recursive -- "${cgroups[@]}") )
+
+    edebug "Checking cgroups are empty: $(lval cgroups exclude recursive pids)"
+
+    # Now just return the result of array_empty on the pids we just found
+    array_empty pids
+}

--- a/share/emock.sh
+++ b/share/emock.sh
@@ -275,17 +275,9 @@ emock()
                 ;;
         esac
 
-        if edebug_enabled; then
-            declare -f ${name}_real
-        fi
-
         # Create a function wrapper to call our mock function instead of the real function.
-        edebug "Creating mock function with $(lval name body)"
+        edebug "Creating mock function with $(lval name)"
         eval "${name} () ${body}"
-
-        if edebug_enabled; then
-            declare -f ${name}
-        fi
 
     else
         edebug "Writing filesystem mock=${name}"

--- a/tests/cgroup.etest
+++ b/tests/cgroup.etest
@@ -150,7 +150,6 @@ ETEST_cgroup_exists()
     assert test ${rc} -eq 2
 }
 
-
 ETEST_cgroup_pids_recursive()
 {
     CGROUP=${ETEST_CGROUP}/${FUNCNAME}
@@ -172,6 +171,34 @@ ETEST_cgroup_pids_recursive()
             assert_true array_contains allPids ${PARENT_PID}
         )
     )
+}
+
+ETEST_cgroup_empty()
+{
+    CGROUP=${ETEST_CGROUP}/${FUNCNAME}
+    CGROUP2=${ETEST_CGROUP}/${FUNCNAME}2
+    trap_add "cgroup_kill_and_wait ${CGROUP} ${CGROUP2}; cgroup_destroy -r ${CGROUP} ${CGROUP2}"
+
+    # Verify newly created group is empty
+    cgroup_create ${CGROUP}
+    cgroup_empty ${CGROUP}
+
+    # Verify multiple groups are supported
+    cgroup_create ${CGROUP2}
+    cgroup_empty ${CGROUP2}
+    cgroup_empty ${CGROUP} ${CGROUP2}
+
+    (
+        cgroup_move ${CGROUP} ${BASHPID}
+        PARENT_PID=${BASHPID}
+
+        cgroup_empty ${CGROUP2}
+        assert_false cgroup_empty ${CGROUP}
+    )
+
+    # Verify after killing a cgroup everything is empty again
+    cgroup_kill_and_wait ${CGROUP} ${CGROUP2}
+    cgroup_empty ${CGROUP} ${CGROUP2}
 }
 
 ETEST_cgroup_move_multiple_pids_at_once()


### PR DESCRIPTION
Well, this was far from easy to track down. But I'm glad I did as this has been plaguing me in various scenarios for ages and I couldn't ever pin this down.

The gist of the problem is that the background processes we launch for `elogfile` (which is what captures all our test output into a logfile in .work directory) were being incorrectly considered process leaks. The fix is in `global_setup` to explicitly move those pids into our parent `ETEST_CGROUP` before we start running all our tests.

Each test gets run in its own child cgroup under `ETEST_CGROUP`. And for some unknown reasons, on some older Linux distros, the original elogfile pids were incorrectly showing up under that cgroup which caused the tests to sometimes fail due to a false positive as a process leak.

The huge upside to this fix also is that we no longer have the potential of leaking the elogfile processes.

I also cleaned up the massive debugging walk from `emock` as I think it's not needed anymore.