### PR TITLE
Use brew bundle to speed up installs on MacOS.

### DIFF
--- a/install/depends
+++ b/install/depends
@@ -171,6 +171,9 @@ elif [ "${DISTRO}" = "darwin" ]; then
         /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
     fi
 
+    # Brew returns an error if you try to install a package that is already installed. The brew solution to this
+    # is to use `brew bundle` which correctly handles this situation. The syntax is a line-delimited file where
+    # each line is `brew "<package name>"`.
     brew bundle --file=- <<-EOF
 		brew "bash"
 		brew "coreutils"

--- a/install/depends
+++ b/install/depends
@@ -182,14 +182,15 @@ elif [ "${DISTRO}" = "darwin" ]; then
         done
     }
 
-    brew_install             \
-        bash                 \
-        coreutils            \
-        findutils            \
-        gawk                 \
-        gnu-sed              \
-        gnu-which            \
-        grep                 \
+    brew bundle --file=- <<-EOF
+		brew "bash"
+		brew "coreutils"
+		brew "findutils"
+		brew "gawk"
+		brew "gnu-sed"
+		brew "gnu-which"
+		brew "grep"
+		EOF
 
 #----------------------------------------------------------------------------------------------------------------------
 #

--- a/install/depends
+++ b/install/depends
@@ -171,17 +171,6 @@ elif [ "${DISTRO}" = "darwin" ]; then
         /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
     fi
 
-    # Brew is lame. If you try to install something that's already installed it returns an error. So we have to first
-    # check if it is installed and skip it if so.
-    brew_install()
-    {
-        for pkg in "${@}"; do
-            if ! brew ls --versions "${pkg}"; then
-                brew install "${pkg}"
-            fi
-        done
-    }
-
     brew bundle --file=- <<-EOF
 		brew "bash"
 		brew "coreutils"

--- a/share/pkg.sh
+++ b/share/pkg.sh
@@ -222,14 +222,11 @@ pkg_install()
 
         brew)
 
-            # Brew is lame. If you try to install something that's already installed and needs an upgrade, it returns
-            # an error. So we have to first check each package to see if they are installed and skip them if so.
-            local name
-            for name in "${names[@]}"; do
-                if ! brew ls --versions "${name}"; then
-                    brew install "${name}"
-                fi
-            done
+            # Brew returns an error if you try to install a package that is already installed. The brew solution to this
+            # is to use `brew bundle` which correctly handles this situation. The syntax is a line-delimited file where
+            # each line is `brew "<package name>"`. We use `printf %q` to get things double quoted properly and put
+            # the `brew ` prefix before each argument in the array then we send that to the STDIN for brew bundle.
+            printf 'brew "%q"\n' "${names[@]}" | brew bundle --file=/dev/stdin
             ;;
 
         pacman)


### PR DESCRIPTION
I want to speed up package installation on MacOS. It is slow b/c with brew you get an error if you try to install a package that is already installed. The brew developers refuse to fix this and say it is by design. Their solution to this is `brew bundle` which gracefully handles this situation.

So this changes ebash over to use `brew bundle`. It's dramatically faster when frequently installing a lot of already installed packages. Takes less than a second vs a couple minutes.