### PR TITLE
Change CI/CD code to be semver compliant with major.minor.patch.

### DIFF
--- a/share/cicd.sh
+++ b/share/cicd.sh
@@ -7,7 +7,8 @@
 # version.
 
 # Global configuration which can be overriden by the caller
-: ${EBASH_CICD_TAG_MATCH:="v*.*.*.*"}
+# This enforces Semantic Versioning 2.0 from https://semver.org/ with MAJOR, MINOR and PATCH.
+: ${EBASH_CICD_TAG_MATCH:="v*.*.*"}
 : ${EBASH_CICD_DEVELOP_BRANCH="develop"}
 : ${EBASH_CICD_RELEASE_BRANCH="main"}
 
@@ -62,24 +63,23 @@ cicd_info()
 
     # If the build is not numeric we can't increment it later
     local version_tag_next
-    if ! is_int "${parts[3]}"; then
+    if ! is_int "${parts[2]}"; then
         version_tag_next=""
-        edebug "Cannot increment non-integer build -- setting version_tag_next to an empty string"
+        edebug "Cannot increment non-integer patch component -- setting version_tag_next to an empty string"
     else
-        version_tag_next="v${parts[0]}.${parts[1]}.${parts[2]}.$(( ${parts[3]:-0} + 1 ))"
+        version_tag_next="v${parts[0]}.${parts[1]}.$(( ${parts[2]:-0} + 1 ))"
     fi
 
     pack_set "${pack}" \
         base_tag="${base_tag}"                                                      \
         branch="$(git rev-parse --abbrev-ref HEAD)"                                 \
-        build="${parts[3]:-0}"                                                      \
         commit="$(git rev-parse HEAD)"                                              \
         commit_short="$(string_truncate 10 $(git rev-parse HEAD))"                  \
         major="${parts[0]}"                                                         \
         minor="${parts[1]}"                                                         \
+        patch="${parts[2]}"                                                         \
         offset="$(git rev-list ${base_tag}..HEAD --count 2>/dev/null || echo 0)"    \
         origin_url="$(git config --get remote.origin.url)"                          \
-        patch="${parts[2]}"                                                         \
         repo_slug="$(basename "$(git config --get remote.origin.url)" ".git")"      \
         series="${parts[0]}.${parts[1]}"                                            \
         version="${version}"                                                        \

--- a/tests/cicd.etest
+++ b/tests/cicd.etest
@@ -37,7 +37,7 @@ setup()
     touch "file1.txt"
     git add "file1.txt"
     git commit -am "Add file1.txt"
-    git tag -am "Tagged by etest" "v1.0.0.0"
+    git tag -am "Tagged by etest" "v1.0.0"
 }
 
 ETEST_cicd_info()
@@ -49,27 +49,26 @@ ETEST_cicd_info()
     cicd_print --json info
 
     etestmsg "Validating CI/CD Info"
-    assert_eq "v1.0.0.0"                            "${base_tag}"
+    assert_eq "v1.0.0"                              "${base_tag}"
     assert_eq "develop"                             "${branch}"
-    assert_eq "0"                                   "${build}"
     assert_eq "$(git rev-parse HEAD)"               "${commit}"
     assert_eq "$(git rev-parse HEAD | cut -c1-10)"  "${commit_short}"
     assert_eq "1"                                   "${major}"
     assert_eq "0"                                   "${minor}"
+    assert_eq "0"                                   "${patch}"
     assert_eq "0"                                   "${offset}"
     assert_eq "git@github.com:elibs/etest.git"      "${origin_url}"
-    assert_eq "0"                                   "${patch}"
     assert_eq "etest"                               "${repo_slug}"
     assert_eq "1.0"                                 "${series}"
-    assert_eq "1.0.0.0"                             "${version}"
-    assert_eq "v1.0.0.0"                            "${version_tag}"
-    assert_eq "v1.0.0.1"                            "${version_tag_next}"
+    assert_eq "1.0.0"                               "${version}"
+    assert_eq "v1.0.0"                              "${version_tag}"
+    assert_eq "v1.0.1"                              "${version_tag_next}"
 }
 
 ETEST_cicd_info_notags()
 {
     etestmsg "Deleting tag created in setup"
-    git tag -d "v1.0.0.0"
+    git tag -d "v1.0.0"
 
     # Create CICD Pack
     etestmsg "Test CI/CD Info"
@@ -78,21 +77,20 @@ ETEST_cicd_info_notags()
     cicd_print --json info
 
     etestmsg "Validating CI/CD Info"
-    assert_eq "v0.0.0.0"                            "${base_tag}"
+    assert_eq "v0.0.0"                              "${base_tag}"
     assert_eq "develop"                             "${branch}"
-    assert_eq "0"                                   "${build}"
     assert_eq "$(git rev-parse HEAD)"               "${commit}"
     assert_eq "$(git rev-parse HEAD | cut -c1-10)"  "${commit_short}"
     assert_eq "0"                                   "${major}"
     assert_eq "0"                                   "${minor}"
+    assert_eq "0"                                   "${patch}"
     assert_eq "0"                                   "${offset}"
     assert_eq "git@github.com:elibs/etest.git"      "${origin_url}"
-    assert_eq "0"                                   "${patch}"
     assert_eq "etest"                               "${repo_slug}"
     assert_eq "0.0"                                 "${series}"
-    assert_eq "0.0.0.0"                             "${version}"
-    assert_eq "v0.0.0.0"                            "${version_tag}"
-    assert_eq "v0.0.0.1"                            "${version_tag_next}"
+    assert_eq "0.0.0"                               "${version}"
+    assert_eq "v0.0.0"                              "${version_tag}"
+    assert_eq "v0.0.1"                              "${version_tag_next}"
 }
 
 ETEST_cicd_info_offset()
@@ -110,21 +108,20 @@ ETEST_cicd_info_offset()
     cicd_print --json info
 
     etestmsg "Validating CI/CD Info"
-    assert_eq "v1.0.0.0"                            "${base_tag}"
+    assert_eq "v1.0.0"                              "${base_tag}"
     assert_eq "develop"                             "${branch}"
-    assert_eq "0"                                   "${build}"
     assert_eq "$(git rev-parse HEAD)"               "${commit}"
     assert_eq "$(git rev-parse HEAD | cut -c1-10)"  "${commit_short}"
     assert_eq "1"                                   "${major}"
     assert_eq "0"                                   "${minor}"
+    assert_eq "0"                                   "${patch}"
     assert_eq "1"                                   "${offset}"
     assert_eq "git@github.com:elibs/etest.git"      "${origin_url}"
-    assert_eq "0"                                   "${patch}"
     assert_eq "etest"                               "${repo_slug}"
     assert_eq "1.0"                                 "${series}"
-    assert_eq "1.0.0.0-1-g${commit_short}"          "${version}"
-    assert_eq "v1.0.0.0-1-g${commit_short}"         "${version_tag}"
-    assert_eq "v1.0.0.1"                            "${version_tag_next}"
+    assert_eq "1.0.0-1-g${commit_short}"            "${version}"
+    assert_eq "v1.0.0-1-g${commit_short}"           "${version_tag}"
+    assert_eq "v1.0.1"                              "${version_tag_next}"
 }
 
 ETEST_cicd_info_print()
@@ -136,21 +133,20 @@ ETEST_cicd_info_print()
     cicd_print info > output
 
 	cat > expect <<-EOF
-	base_tag="v1.0.0.0"
+	base_tag="v1.0.0"
 	branch="develop"
-	build="0"
 	commit="${commit}"
 	commit_short="${commit_short}"
 	major="1"
 	minor="0"
+	patch="0"
 	offset="0"
 	origin_url="git@github.com:elibs/etest.git"
-	patch="0"
 	repo_slug="etest"
 	series="1.0"
-	version="1.0.0.0"
-	version_tag="v1.0.0.0"
-	version_tag_next="v1.0.0.1"
+	version="1.0.0"
+	version_tag="v1.0.0"
+	version_tag_next="v1.0.1"
 	EOF
 
     einfo "Expect"
@@ -172,21 +168,20 @@ ETEST_cicd_info_print_json()
 
 	cat > expect.json <<-EOF
 	{
-	  "base_tag": "v1.0.0.0",
+	  "base_tag": "v1.0.0",
 	  "branch": "develop",
-	  "build": "0",
 	  "commit": "${commit}",
 	  "commit_short": "${commit_short}",
 	  "major": "1",
 	  "minor": "0",
+	  "patch": "0",
 	  "offset": "0",
 	  "origin_url": "git@github.com:elibs/etest.git",
-	  "patch": "0",
 	  "repo_slug": "etest",
 	  "series": "1.0",
-	  "version": "1.0.0.0",
-	  "version_tag": "v1.0.0.0",
-	  "version_tag_next": "v1.0.0.1"
+	  "version": "1.0.0",
+	  "version_tag": "v1.0.0",
+	  "version_tag_next": "v1.0.1"
 	}
 	EOF
 
@@ -208,21 +203,20 @@ ETEST_cicd_info_print_uppercase()
     cicd_print --uppercase info > output
 
 	cat > expect <<-EOF
-	BASE_TAG="v1.0.0.0"
+	BASE_TAG="v1.0.0"
 	BRANCH="develop"
-	BUILD="0"
 	COMMIT="${commit}"
 	COMMIT_SHORT="${commit_short}"
 	MAJOR="1"
 	MINOR="0"
+	PATCH="0"
 	OFFSET="0"
 	ORIGIN_URL="git@github.com:elibs/etest.git"
-	PATCH="0"
 	REPO_SLUG="etest"
 	SERIES="1.0"
-	VERSION="1.0.0.0"
-	VERSION_TAG="v1.0.0.0"
-	VERSION_TAG_NEXT="v1.0.0.1"
+	VERSION="1.0.0"
+	VERSION_TAG="v1.0.0"
+	VERSION_TAG_NEXT="v1.0.1"
 	EOF
 
     einfo "Expect"
@@ -249,21 +243,20 @@ ETEST_cicd_create_next_version_tag()
     cicd_print --json info
 
     etestmsg "Validating CI/CD Info"
-    assert_eq "v1.0.0.1"                            "${base_tag}"
+    assert_eq "v1.0.1"                              "${base_tag}"
     assert_eq "develop"                             "${branch}"
-    assert_eq "1"                                   "${build}"
     assert_eq "$(git rev-parse HEAD)"               "${commit}"
     assert_eq "$(git rev-parse HEAD | cut -c1-10)"  "${commit_short}"
     assert_eq "1"                                   "${major}"
     assert_eq "0"                                   "${minor}"
+    assert_eq "1"                                   "${patch}"
     assert_eq "0"                                   "${offset}"
     assert_eq "git@github.com:elibs/etest.git"      "${origin_url}"
-    assert_eq "0"                                   "${patch}"
     assert_eq "etest"                               "${repo_slug}"
     assert_eq "1.0"                                 "${series}"
-    assert_eq "1.0.0.1"                             "${version}"
-    assert_eq "v1.0.0.1"                            "${version_tag}"
-    assert_eq "v1.0.0.2"                            "${version_tag_next}"
+    assert_eq "1.0.1"                               "${version}"
+    assert_eq "v1.0.1"                              "${version_tag}"
+    assert_eq "v1.0.2"                              "${version_tag_next}"
 }
 
 ETEST_cicd_create_next_version_tag_push()


### PR DESCRIPTION
The CI/CD versioning ebash creates is not semver compliant (https://semver.org/). Semver only officially supports 3 octets -- major.minor.patch. And more importantly, Go only supports 3 octets. So I'm changing ebash CI/CD versioning to also be semver compliant.