### PR TITLE
Add new conf_to_json to easily convert a conf map to structured JSON

### DIFF
--- a/share/conf.sh
+++ b/share/conf.sh
@@ -355,8 +355,8 @@ conf_to_json()
     {
         echo "{"
 
-        local idx=0
-        local idx_last=$(( $(array_size ${__conf_store}) - 1 ))
+        local idx=0 idx_last=0
+        idx_last=$(( $(array_size ${__conf_store}) - 1 ))
 
         for key in $(array_indexes_sort ${__conf_store}) ; do
             echo '"'${key}'": {'

--- a/share/conf.sh
+++ b/share/conf.sh
@@ -329,3 +329,63 @@ conf_props()
 
     pack_keys "${__conf_store}[$section]"
 }
+
+opt_usage conf_to_json  <<'END'
+conf_to_json converts the named configuration to an anonymous JSON object. Each named section in the configratuion will
+be a top-level named JSON object. Each property inside that section will then be a series of '"key": "value"' pairs in
+the JSON. By defualt, all the properties are displayed as quoted strings. But this can be controlled via --props-int to
+not quote the values as they are known to be integers. Alternatively the properties can be automatically split on
+whitespace and printed as a JSON array.
+
+For some detailed examples see `tests/conf.etest`:
+
+ETEST_conf_to_json
+ETEST_conf_to_json_int
+ETEST_conf_to_json_array
+...
+END
+conf_to_json()
+{
+    $(opt_parse \
+        "+props_int   | Display all props as ints instead of strings." \
+        "+props_array | Split all props into arrays."                  \
+        "__conf_store | Variable containing the configuration data."   \
+    )
+
+    {
+        echo "{"
+
+        local idx=0
+        local idx_last=$(( $(array_size ${__conf_store}) - 1 ))
+
+        for key in $(array_indexes_sort ${__conf_store}) ; do
+            echo '"'${key}'": {'
+            pack_iterate _conf_json_helper "${__conf_store}[$key]" | sed 's|,$||'
+
+            if [[ "${idx}" -lt "${idx_last}" ]]; then
+                echo "},"
+            else
+                echo "}"
+            fi
+
+            (( idx += 1 ))
+
+        done
+
+        echo "}"
+
+    } | jq .
+}
+
+_conf_json_helper()
+{
+    if [[ "${props_array}" -eq 1 ]]; then
+        local parts=()
+        array_init parts "$2"
+        printf '"%s": %s,' "$1" "$(array_to_json parts)"
+    elif [[ "${props_int}" -eq 1 ]]; then
+        printf '"%s": %s,' "$1" "$2"
+    else
+        printf '"%s": "%s",' "$1" "$2"
+    fi
+}

--- a/tests/conf.etest
+++ b/tests/conf.etest
@@ -398,6 +398,56 @@ ETEST_conf_to_json()
     diff -u expect actual
 }
 
+ETEST_conf_to_json_default_section()
+{
+	cat >file <<-END
+	branches = 50
+	functions = 50
+	lines = 50
+	statements = 50
+
+	[src/components/check]
+	lines = 50
+	statements = 50
+
+	[src/components/credentials]
+	branches = 50
+	functions = 50
+	END
+
+    cat >expect <<-END
+	{
+	  "default": {
+	    "branches": "50",
+	    "functions": "50",
+	    "lines": "50",
+	    "statements": "50"
+	  },
+	  "src/components/check": {
+	    "lines": "50",
+	    "statements": "50"
+	  },
+	  "src/components/credentials": {
+	    "branches": "50",
+	    "functions": "50"
+	  }
+	}
+	END
+
+    etestmsg "Data"
+    declare -A CONF
+    conf_read CONF file
+    conf_dump CONF
+
+    etestmsg "ToJson"
+    conf_to_json CONF > actual
+    cat actual | jq --color-output
+
+    etestmsg "Validating"
+    diff -u expect actual
+}
+
+
 ETEST_conf_to_json_int()
 {
 	cat >file <<-END

--- a/tests/conf.etest
+++ b/tests/conf.etest
@@ -392,7 +392,7 @@ ETEST_conf_to_json()
 
     etestmsg "ToJson"
     conf_to_json CONF > actual
-    cat actual | jq --color-output
+    jq . actual
 
     etestmsg "Validating"
     diff -u expect actual
@@ -441,7 +441,7 @@ ETEST_conf_to_json_default_section()
 
     etestmsg "ToJson"
     conf_to_json CONF > actual
-    cat actual | jq --color-output
+    jq . actual
 
     etestmsg "Validating"
     diff -u expect actual
@@ -493,7 +493,7 @@ ETEST_conf_to_json_int()
 
     etestmsg "ToJson (int)"
     conf_to_json --props-int CONF > actual
-    cat actual | jq --color-output
+    jq . actual
 
     etestmsg "Validating"
     diff -u expect actual
@@ -548,7 +548,7 @@ ETEST_conf_to_json_array()
 
     etestmsg "ToJson (array)"
     conf_to_json --props-array CONF > actual
-    cat actual | jq --color-output
+    jq . actual
 
     etestmsg "Validating"
     diff -u expect actual

--- a/tests/conf.etest
+++ b/tests/conf.etest
@@ -347,3 +347,159 @@ ETEST_conf_sections()
     conf_sections CONF
     assert_eq "section_x section_y section_z" "$(conf_sections CONF)"
 }
+
+ETEST_conf_to_json()
+{
+	cat >file <<-END
+	[global]
+	branches = 50
+	functions = 50
+	lines = 50
+	statements = 50
+
+	[src/components/check]
+	lines = 50
+	statements = 50
+
+	[src/components/credentials]
+	branches = 50
+	functions = 50
+	END
+
+    cat >expect <<-END
+	{
+	  "global": {
+	    "branches": "50",
+	    "functions": "50",
+	    "lines": "50",
+	    "statements": "50"
+	  },
+	  "src/components/check": {
+	    "lines": "50",
+	    "statements": "50"
+	  },
+	  "src/components/credentials": {
+	    "branches": "50",
+	    "functions": "50"
+	  }
+	}
+	END
+
+    etestmsg "Data"
+    declare -A CONF
+    conf_read CONF file
+    conf_dump CONF
+
+    etestmsg "ToJson"
+    conf_to_json CONF > actual
+    cat actual | jq --color-output
+
+    etestmsg "Validating"
+    diff -u expect actual
+}
+
+ETEST_conf_to_json_int()
+{
+	cat >file <<-END
+	[global]
+	branches = 50
+	functions = 50
+	lines = 50
+	statements = 50
+
+	[src/components/check]
+	lines = 50
+	statements = 50
+
+	[src/components/credentials]
+	branches = 50
+	functions = 50
+	END
+
+    cat >expect <<-END
+	{
+	  "global": {
+	    "branches": 50,
+	    "functions": 50,
+	    "lines": 50,
+	    "statements": 50
+	  },
+	  "src/components/check": {
+	    "lines": 50,
+	    "statements": 50
+	  },
+	  "src/components/credentials": {
+	    "branches": 50,
+	    "functions": 50
+	  }
+	}
+	END
+
+
+    etestmsg "Data"
+    declare -A CONF
+    conf_read CONF file
+    conf_dump CONF
+
+    etestmsg "ToJson (int)"
+    conf_to_json --props-int CONF > actual
+    cat actual | jq --color-output
+
+    etestmsg "Validating"
+    diff -u expect actual
+}
+
+ETEST_conf_to_json_array()
+{
+	cat >file <<-END
+	[settings]
+	modules = os go
+
+	[os]
+	all = foo bar zap
+
+	[go]
+	foo = some_url
+    bar = another_url with spaces
+	END
+
+    cat >expect <<-END
+	{
+	  "go": {
+	    "foo": [
+	      "some_url"
+	    ],
+	    "bar": [
+	      "another_url",
+	      "with",
+	      "spaces"
+	    ]
+	  },
+	  "os": {
+	    "all": [
+	      "foo",
+	      "bar",
+	      "zap"
+	    ]
+	  },
+	  "settings": {
+	    "modules": [
+	      "os",
+	      "go"
+	    ]
+	  }
+	}
+	END
+
+    etestmsg "Data"
+    declare -A CONF
+    conf_read CONF file
+    conf_dump CONF
+
+    etestmsg "ToJson (array)"
+    conf_to_json --props-array CONF > actual
+    cat actual | jq --color-output
+
+    etestmsg "Validating"
+    diff -u expect actual
+}


### PR DESCRIPTION
This adds `conf_to_json` to convert a named configuration to an anonymous JSON object. Each named section in the configratuion will be a top-level named JSON object. Each property inside that section will then be a series of `'"key": "value"'` pairs in the JSON. 

By default, all the properties are displayed as quoted strings. But this can be controlled via `--props-int` to not quote the values as they are known to be integers. Alternatively the properties can be automatically split on whitespace and printed as a JSON array using `--props-array`.

For some detailed examples see `tests/conf.etest`:
* ETEST_conf_to_json
* ETEST_conf_to_json_int
 * ETEST_conf_to_json_array