### PR TITLE
Nodejs fixes

### DIFF
--- a/install/nodejs
+++ b/install/nodejs
@@ -217,7 +217,11 @@ install_nodejs()
 
         # Add symlinks to <install_prefix>/bin for all node binaries
         einfo "Creating symbolic links for node binaries"
-        ln -sv "${install_prefix}/node/bin/"* "${install_prefix}/bin"
+        for file in "${install_prefix}/node/bin/*"; do
+            file_to_link=$(readlink -f "${file}")
+            linked_file=$(basename "${file}")
+            ln -sv "${file_to_link}" "${install_prefix}/bin/${linked_file}"
+        done
 
         # Verify installation
         verify_symlinks --install-prefix "${install_prefix}" --lts-version "${lts_version}"

--- a/install/nodejs
+++ b/install/nodejs
@@ -217,7 +217,7 @@ install_nodejs()
 
         # Add symlinks to <install_prefix>/bin for all node binaries
         einfo "Creating symbolic links for node binaries"
-        for file in "${install_prefix}/node/bin/*"; do
+        for file in ${install_prefix}/node/bin/*; do
             file_to_link=$(readlink -f "${file}")
             linked_file=$(basename "${file}")
             ln -sv "${file_to_link}" "${install_prefix}/bin/${linked_file}"

--- a/install/nodejs
+++ b/install/nodejs
@@ -189,6 +189,12 @@ install_nodejs()
 
         # Workaround issue with Catalina
         command_exists "npm" || brew link "node@${mac_lts_version}"
+    elif os_distro alpine; then
+
+        # nodejs precompiled binaries are against glib, and alpine needs musl
+        # for now, use whatever alpine is providing
+        edebug "Use alpines package manager to install nodejs and friends."
+        pkg_install --sync npm nodejs
 
     # If the distro is linux, always download the lts codename's latest versioned binary
     elif os linux; then

--- a/install/nodejs
+++ b/install/nodejs
@@ -196,6 +196,8 @@ install_nodejs()
         edebug "Use alpines package manager to install nodejs and friends."
         pkg_install --sync npm nodejs
 
+        einfo "$(npm -v)"
+
     # If the distro is linux, always download the lts codename's latest versioned binary
     elif os linux; then
 

--- a/tests/nodejs_install.etest
+++ b/tests/nodejs_install.etest
@@ -150,7 +150,12 @@ ETEST_install_node_non_supported()
     local test_prefix_dir="${TEST_DIR_OUTPUT}/${test_prefix}"
 
     emock --stdout "${lts_version}" --return 0 "get_latest_node_version"
+
+    # Fail all os checks
     emock --return 1 "os"
+
+    # Ignore alpine
+    emock --return 1 "os_distro"
 
     assert_false install_nodejs --install-prefix "${test_prefix_dir}" --lts-codename "${lts_codename}"
 }
@@ -204,6 +209,9 @@ ETEST_install_node_linux()
             return 1
         fi
     }'
+
+    # Ignore alpine, as we use apk to install nodejs currently on alpine
+    emock --return 1 "os_distro"
 
     # Make the call
     install_nodejs --install-prefix "${test_prefix_dir}" --lts-codename "${lts_codename}"


### PR DESCRIPTION
Well, it's hard to use glib binaries on a musl system. Nodejs install will use alpine's default package instead of the available binary.