### PR TITLE
Fix conflation of path and filename in nodejs install.

### DIFF
--- a/install/nodejs
+++ b/install/nodejs
@@ -21,7 +21,8 @@ END
 #----------------------------------------------------------------------------------------------------------------------
 
 default_prefix="/usr/local"
-default_sha_path="/tmp/SHASUMS256.txt"
+default_sha_output_path="/tmp/"
+default_sha_path="${default_sha_output_path}/SHASUMS256.txt"
 nodejs_codename="gallium"
 lts_url="https://nodejs.org/download/release/latest-${nodejs_codename}/"
 
@@ -138,8 +139,9 @@ retrieve_sha()
         ":sha_output_path  o | The place to store the sha"         \
     )
 
+    local sha_url
     einfo "Retrieving SHASUM256.txt for codename ${lts_codename}"
-    local sha_url="https://nodejs.org/download/release/latest-${lts_codename}/SHASUMS256.txt"
+    sha_url="https://nodejs.org/download/release/latest-${lts_codename}/SHASUMS256.txt"
     edebug "Using url: ${sha_url}"
 
     # Download SHA256 to determine version
@@ -156,12 +158,15 @@ get_latest_node_version()
         ":sha_output_path o | The path where the sha should be saved"
     )
 
+    local basename="SHASUMS256.txt"
+
     # Retrieve the sha file and apply cleanup
     retrieve_sha --lts-codename "${lts_codename}" --sha-output-path "${sha_output_path}"
-    trap_add "rm -f ${sha_output_path}"
+    trap_add "rm -f ${sha_output_path}/${basename}"
 
-    edebug "$(cat "${sha_output_path}")"
-    grep "node-v" "${sha_output_path}" | head -n 1 | awk -F- '{ print $2 }' | sed 's/v//g'
+    edebug "$(cat "${sha_output_path}/${basename}")"
+
+    grep "node-v" "${sha_output_path}/${basename}" | head -n 1 | awk -F- '{ print $2 }' | sed 's/v//g'
 }
 
 opt_usage install_node <<'END'
@@ -174,7 +179,7 @@ install_nodejs()
         ":lts_codename   c | The codename for the lts version to install"
     )
 
-    lts_version=$(get_latest_node_version --lts-codename "${lts_codename}" --sha-output-path "${default_sha_path}")
+    lts_version=$(get_latest_node_version --lts-codename "${lts_codename}" --sha-output-path "${default_sha_output_path}")
     einfo "Installing latest version of nodejs codename '${lts_codename}': ${lts_version}"
 
     if os darwin; then

--- a/install/nodejs
+++ b/install/nodejs
@@ -21,7 +21,7 @@ END
 #----------------------------------------------------------------------------------------------------------------------
 
 default_prefix="/usr/local"
-default_sha_output_path="/tmp/"
+default_sha_output_path="/tmp"
 default_sha_path="${default_sha_output_path}/SHASUMS256.txt"
 nodejs_codename="gallium"
 lts_url="https://nodejs.org/download/release/latest-${nodejs_codename}/"
@@ -136,7 +136,7 @@ retrieve_sha()
 {
     $(opt_parse                                                    \
         ":lts_codename     c | The codename of the lts to install" \
-        ":sha_output_path  o | The place to store the sha"         \
+        ":sha_output_dir  o | The place to store the sha"         \
     )
 
     local sha_url
@@ -145,7 +145,7 @@ retrieve_sha()
     edebug "Using url: ${sha_url}"
 
     # Download SHA256 to determine version
-    eretry efetch --style=einfo "${sha_url}" "${sha_output_path}" |& edebug
+    eretry efetch --style=einfo "${sha_url}" "${sha_output_dir}" |& edebug
 }
 
 opt_usage get_latest_node_version <<'END'
@@ -155,18 +155,18 @@ get_latest_node_version()
 {
     $(opt_parse                                                                    \
         ":lts_codename    c | The lts codename to retrieve the latest version for" \
-        ":sha_output_path o | The path where the sha should be saved"
+        ":sha_output_dir o | The path where the sha should be saved"
     )
 
     local basename="SHASUMS256.txt"
 
     # Retrieve the sha file and apply cleanup
-    retrieve_sha --lts-codename "${lts_codename}" --sha-output-path "${sha_output_path}"
-    trap_add "rm -f ${sha_output_path}/${basename}"
+    retrieve_sha --lts-codename "${lts_codename}" --sha-output-dir "${sha_output_dir}"
+    trap_add "rm -f ${sha_output_dir}/${basename}"
 
-    edebug "$(cat "${sha_output_path}/${basename}")"
+    edebug "$(cat "${sha_output_dir}/${basename}")"
 
-    grep "node-v" "${sha_output_path}/${basename}" | head -n 1 | awk -F- '{ print $2 }' | sed 's/v//g'
+    grep "node-v" "${sha_output_dir}/${basename}" | head -n 1 | awk -F- '{ print $2 }' | sed 's/v//g'
 }
 
 opt_usage install_node <<'END'
@@ -179,7 +179,7 @@ install_nodejs()
         ":lts_codename   c | The codename for the lts version to install"
     )
 
-    lts_version=$(get_latest_node_version --lts-codename "${lts_codename}" --sha-output-path "${default_sha_output_path}")
+    lts_version=$(get_latest_node_version --lts-codename "${lts_codename}" --sha-output-dir "${default_sha_output_path}")
     einfo "Installing latest version of nodejs codename '${lts_codename}': ${lts_version}"
 
     if os darwin; then

--- a/tests/nodejs_install.etest
+++ b/tests/nodejs_install.etest
@@ -219,7 +219,7 @@ ETEST_install_node_linux()
     # Verify correct Mocks
     assert_emock_called_with "get_latest_node_version" 0 \
         --lts-codename "${lts_codename}"                 \
-        --sha-output-path "${default_sha_path}"
+        --sha-output-dir "${default_sha_output_path}"
 
     assert_emock_called_with "eretry" 0 \
         efetch --style=einfo "${test_url}" "${tarball}"
@@ -275,7 +275,7 @@ ETEST_install_node_mac()
     # Verify the mocks being called correctly
     assert_emock_called_with "get_latest_node_version" 0 \
         --lts-codename "${lts_codename}"                 \
-        --sha-output-path "${default_sha_path}"
+        --sha-output-dir "${default_sha_output_path}"
 
     assert_emock_called_with "os" 0 \
         darwin
@@ -360,7 +360,6 @@ ETEST_get_latest_node_version()
 {
     local codename="gallium"
     local expected_version="16.13.2"
-    local sha_file="${TEST_DIR_OUTPUT}/nodejs_SHASUMS256.txt"
 
     # Establish mock
     emock "retrieve_sha" '
@@ -368,11 +367,13 @@ ETEST_get_latest_node_version()
         return 0
     }'
 
+    sha_file="${default_sha_output_path}/SHASUMS256.txt"
+
     # Test Legit version
     cat > "${sha_file}" <<-END
 451367428b40095656133  node-v16.13.2-aix-ppc64.tar.gz
 END
-    actual_version=$(get_latest_node_version --lts-codename "${codename}" --sha-output-path "${sha_file}")
+    actual_version=$(get_latest_node_version --lts-codename "${codename}" --sha-output-dir "${default_sha_output_path}")
     assert_eq "${expected_version}" "${actual_version}"
 
     # Test Bogus version
@@ -380,7 +381,7 @@ END
 451367428b40095656133  node-.13.2-aix-ppc64.tar.gz
 END
 
-    assert_false get_latest_node_version --lts-codename "${codename}" --sha-output-path "${sha_file}"
+    assert_false get_latest_node_version --lts-codename "${codename}" --sha-output-dir "${default_sha_output_path}"
     assert_not_exists "${sha_file}"
 }
 


### PR DESCRIPTION
Internally this script was referencing a filepath instead of a folder path.