### PR TITLE
Docker compose

### DIFF
--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -1,19 +1,22 @@
 ARG IMAGE
 FROM ${IMAGE}
 
-# Copy install directory. This is what will trigger new builds when dependencies change.
+# Install build dependencies (e.g. unzip is needed)
 COPY docker/setup /ebash-build/docker/setup
-COPY install /ebash-build/install
-RUN sed -i -e 's|${EBASH_HOME}|/ebash-build|g' /ebash-build/install/all
-RUN sed -i -e 's|: ${EBASH_HOME:=$(dirname $0)/..}|EBASH_HOME="/ebash-main"|' /ebash-build/install/*
-
-# Install build dependencies
 RUN /ebash-build/docker/setup
 
 # Fetch ebash from master as an opaque thing to avoid using our local code. That way we
 # don't invalidate our image.
 RUN curl --location --remote-name https://github.com/elibs/ebash/archive/main.zip
 RUN unzip main.zip
+RUN mv /ebash-main /ebash
+
+# Copy install directory over the top of the latest stable version that we just unpacked above.
+# This is what will trigger new builds when dependencies change.
+COPY install /ebash/install
+RUN sed -i -e 's|${EBASH_HOME}|/ebash|g' /ebash/install/all
+RUN sed -i -e 's|: ${EBASH_HOME:=$(dirname $0)/..}|EBASH_HOME="/ebash"|' /ebash/install/*
+RUN cat /ebash/install/shellcheck
 
 # Install all dependencies
-RUN /ebash-build/install/all
+RUN /ebash/install/all

--- a/docker/setup
+++ b/docker/setup
@@ -71,6 +71,10 @@ elif [ "${DISTRO}" = "arch" ]; then
 #----------------------------------------------------------------------------------------------------------------------
 elif [ "${DISTRO}" = "centos" ]; then
 
+    sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    yum update -y
+
     yum install epel-release -y
 
     yum install -y          \

--- a/docker/setup
+++ b/docker/setup
@@ -71,9 +71,13 @@ elif [ "${DISTRO}" = "arch" ]; then
 #----------------------------------------------------------------------------------------------------------------------
 elif [ "${DISTRO}" = "centos" ]; then
 
-    sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
-    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
-    yum update -y
+    # CentOS 8 packages have all moved from centos merrors to vault.centos.org so we have to update things appropriately
+    if [ "$(awk -F'[="]*' '/^VERSION_ID=/ {print $2}' /etc/os-release)" = "8" ]; then
+        echo "Updating from mirror.centos.org -> vault.centos.org"
+        sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+        sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+        yum update -y
+    fi
 
     yum install epel-release -y
 

--- a/install/go
+++ b/install/go
@@ -41,9 +41,29 @@ elif os linux; then
 
     einfo "Go not available via package manager on $(os_pretty_name). Downloading from official Go URL."
 
-    # Download
-    version="$(curl --silent --location https://golang.org/VERSION?m=text)"
-    url="https://dl.google.com/go/${version}.linux-amd64.tar.gz"
+    # Find a verison we can download. We used to just use the latest version as defined by calling
+    # `curl --silent --location https://golang.org/VERSION?m=text` but unfortunately that is sometimes ahead of the
+    # versions that you can actually download via go.dev/dl. So instead, what we do now is use the provided golang.org
+    # URL which provides a LIST of downloadable versions. And we'll just try one at a time until we find one we can
+    # successfully download.
+    url=""
+    versions=()
+    readarray -t versions < <(curl --silent -L https://golang.org/dl/?mode=json | jq --raw-output '.[].version')
+    for version in "${versions[@]}"; do
+        url_candidate="https://go.dev/dl/${version}.linux-amd64.tar.gz"
+        edebug "Checking $(lval version url_candidate)"
+        if curl --output /dev/null --silent --head --fail "${url_candidate}"; then
+            edebug "${version} is avaiable for download"
+            url="${url_candidate}"
+            break
+        fi
+    done
+
+    if [[ -z "${url}" ]]; then
+        die "Unable to find a downloadable version of Go"
+    fi
+
+    # Now download the URL
     : ${TMPDIR:=/tmp}
     tarball="${TMPDIR}/$(basename "${url}")"
     mkdir -p "$(dirname "${tarball}")"

--- a/install/shellcheck
+++ b/install/shellcheck
@@ -27,7 +27,7 @@ ebanner --uppercase "Installing ShellCheck package" OS
 
 # Determine what the name of the package is to install on this OS/Distro (if any).
 package=""
-if os darwin || os_distro alpine arch; then
+if os darwin || os_distro alpine; then
     package="shellcheck"
 elif os_distro fedora; then
     package="ShellCheck"

--- a/share/checkbox.sh
+++ b/share/checkbox.sh
@@ -60,14 +60,18 @@ checkbox_eend()
                          value will emit '[✘]'." \
     )
 
+    {
+        printf "\r"
 
-    printf "\r"
+        if [[ "${return_code}" -eq 0 ]]; then
+            echo "$(tput setaf 2)$(tput bold)[✓]$(tput sgr0)"
+        else
+            echo "$(tput setaf 1)$(tput bold)[✘]$(tput sgr0)"
+        fi
 
-    if [[ "${return_code}" -eq 0 ]]; then
-        echo "$(tput setaf 2)$(tput bold)[✓]$(tput sgr0)"
-    else
-        echo "$(tput setaf 1)$(tput bold)[✘]$(tput sgr0)"
-    fi
+        printf "\r"
+
+    } >&2
 }
 
 opt_usage checkbox <<'END'

--- a/share/docker.sh
+++ b/share/docker.sh
@@ -895,7 +895,7 @@ docker_compose_run()
     # The tailing of the logfile will run in the foreground and block until the parent docker-compose job completes.
     edebug "Calling docker-compose with $(lval docker_args)"
     local pid
-    docker-compose --verbose "${docker_args[@]}" run ${*:-} |& edebug &
+    docker-compose --verbose "${docker_args[@]}" run -T ${*:-} |& edebug &
     pid=$!
     edebug "Backgrounded docker-compose with $(lval pid)"
 
@@ -951,7 +951,7 @@ docker_compose_run()
         docker logs "${id}" --follow | tee "${logfile}"
     elif [[ -n "${follow_json}" ]]; then
         id=$(docker-compose --file "${file}" ps -q "${follow_json}")
-        docker logs "${id}" --follow | tee "${logfile}" | jq -R '. as $line | try (fromjson) catch $line'
+        docker logs "${id}" --follow | tee "${logfile}" | jq --unbuffered --raw-input '. as $line | try (fromjson) catch $line'
     fi
 
     # Wait on our backgrounded process and propogate any failure from it.

--- a/share/docker.sh
+++ b/share/docker.sh
@@ -856,6 +856,9 @@ docker_compose_run()
                                               necessary cleanup. This is a useful mechanism to ensure we bring down all
                                               containers and volumes via teardown='down --volumes --remove-orphans'"   \
         "+wait=1                            | Wait for ready status"                                                   \
+        ":wait_services                     | Explicit list of whitespace separated services to wait for. If not
+                                              provided all services will be waited on during startup. This only applies
+                                              if wait=1."                                                              \
         ":wait_delay=1s                     | How long to wait between checks for service health during wait."         \
     )
 
@@ -900,7 +903,11 @@ docker_compose_run()
     if [[ ${wait} -eq 1 ]]; then
 
         local id status service services=()
-        readarray -t services < <(docker-compose --file "${file}" ps --services)
+        if [[ -n "${wait_services}" ]]; then
+            array_init services "${wait_services}"
+        else
+            readarray -t services < <(docker-compose --file "${file}" ps --services)
+        fi
 
         echo
         einfo "Waiting for $(lval services)"

--- a/share/docker.sh
+++ b/share/docker.sh
@@ -924,7 +924,7 @@ docker_compose_run()
                     elif [[ "${status}" == "null" ]]; then
                         status=$(docker inspect "${id}" | jq --raw-output '.[0].State.Status')
 
-                        if [[ "${status}" == "running" ]]; then
+                        if [[ "${status}" == @(exited|running) ]]; then
                             break
                         fi
                     fi

--- a/share/docker.sh
+++ b/share/docker.sh
@@ -902,10 +902,11 @@ docker_compose_run()
 
         local id status service services=()
         readarray -t services < <(docker-compose --file "${file}" ps --services)
+        echo
         einfo "Waiting for $(lval services)"
         for service in "${services[@]}"; do
 
-            einfos "${service}"
+            checkbox_open_timer "${service}"
 
             while true; do
 
@@ -920,13 +921,13 @@ docker_compose_run()
                     status=$(docker inspect "${id}" | jq --raw-output '.[0].State.Health.Status')
                     edebug "$(lval service status)"
                     if [[ "${status}" == "healthy" ]]; then
-                        eend 0
+                        checkbox_close
                         break
                     elif [[ "${status}" == "null" ]]; then
                         status=$(docker inspect "${id}" | jq --raw-output '.[0].State.Status')
 
                         if [[ "${status}" == "running" ]]; then
-                            eend 0
+                            checkbox_close
                             break
                         fi
                     fi

--- a/share/docker.sh
+++ b/share/docker.sh
@@ -685,6 +685,53 @@ docker_export()
     eprogress_kill
 }
 
+__docker_setup_copy_volumes()
+{
+    $(opt_parse \
+        "+add_volume_to_args | Whether to add --volume flags to docker_args" \
+    )
+
+    # Deal with all copy_to_volumes
+    local entry name parts
+    for entry in ${copy_to_volume[*]:-}; do
+
+        array_init parts "${entry}" ":"
+        assert_eq 3 "$(array_size parts)"
+        local name=${parts[0]}
+        local lpath=${parts[1]}
+        local rpath=${parts[2]}
+
+        edebug "Creating docker container for volume $(lval name lpath rpath)"
+        docker container create --name "${name}" -v "${name}:${rpath}" busybox | edebug
+        trap_add "docker volume rm ${name} |& edebug"
+        trap_add "docker rm ${name} |& edebug"
+        docker cp "${lpath}/." "${name}:${rpath}"
+
+        if [[ "${add_volume_to_args}" -eq 1 ]]; then
+            docker_args+=( --volume="${name}:${rpath}" )
+        fi
+    done
+
+    # Setup traps for copy_from_volume
+    for entry in ${copy_from_volume[*]:-}; do
+
+        array_init parts "${entry}" ":"
+        assert_eq 3 "$(array_size parts)"
+        local name=${parts[0]}
+        local rpath=${parts[1]}
+        local lpath=${parts[2]}
+
+        edebug "Setting trap to copy from $(lval name rpath lpath)"
+        trap_add "docker cp ${name}:${rpath}/. ${lpath}"
+    done
+
+    # Setup traps for copy_from_volume_delete
+    for entry in ${copy_from_volume_delete[*]:-}; do
+        edebug "Setting trap to delete $(lval entry) post-copy"
+        trap_add "rm --recursive --force \"${entry}\""
+    done
+}
+
 opt_usage docker_run <<'END'
 `docker_run` is an intelligent wrapper around vanilla `docker run` which integrates nicely with ebash. In addition to
 the normal additional error checking and hardening the ebash variety brings, this version provides the following super
@@ -742,43 +789,8 @@ docker_run()
         docker_args+=( --mount "type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock" )
     fi
 
-    # Deal with all copy_to_volumes
-    local entry name parts
-    for entry in ${copy_to_volume[*]:-}; do
-
-        array_init parts "${entry}" ":"
-        assert_eq 3 "$(array_size parts)"
-        local name=${parts[0]}
-        local lpath=${parts[1]}
-        local rpath=${parts[2]}
-
-        edebug "Creating docker container for volume $(lval name lpath rpath)"
-        docker container create --name "${name}" -v "${name}:${rpath}" busybox | edebug
-        trap_add "docker volume rm ${name} |& edebug"
-        trap_add "docker rm ${name} |& edebug"
-        docker cp "${lpath}/." "${name}:${rpath}"
-
-        docker_args+=( --volume="${name}:${rpath}" )
-    done
-
-    # Setup traps for copy_from_volume
-    for entry in ${copy_from_volume[*]:-}; do
-
-        array_init parts "${entry}" ":"
-        assert_eq 3 "$(array_size parts)"
-        local name=${parts[0]}
-        local rpath=${parts[1]}
-        local lpath=${parts[2]}
-
-        edebug "Setting trap to copy from $(lval name rpath lpath)"
-        trap_add "docker cp ${name}:${rpath}/. ${lpath}"
-    done
-
-    # Setup traps for copy_from_volume_delete
-    for entry in ${copy_from_volume_delete[*]:-}; do
-        edebug "Setting trap to delete $(lval entry) post-copy"
-        trap_add "rm --recursive --force \"${entry}\""
-    done
+    # Setup copy_to_volumes and copy_from_volume and copy_from_volume_delete
+    __docker_setup_copy_volumes --add-volume-to-args
 
     # Set --interactive as requested
     if [[ "${interactive,,}" == "yes" ]]; then
@@ -802,26 +814,25 @@ docker_run()
 }
 
 opt_usage docker_compose <<'END'
-`docker_compose` is an intelligent wrapper around vanilla `docker-compose` which integrates nicely with ebash. In
+`docker_compose_run` is an intelligent wrapper around vanilla `docker-compose` which integrates nicely with ebash. In
 addition to the normal additional error checking and hardening the ebash variety brings, this version provides the
 following super useful features:
 
-- Accept a list of environment variables which should be exported into the underlying docker run command. Each of these
-  variables will be expanded in-place by ebash using `expand_vars`. As such the variables can be a simple list of env
-  variables to export as in `FOO BAR ZAP` or they can point to other variables as in `FOO=PWD BAR ZAP` or they can
-  point to string literals as in `FOO=/home/marshall BAR=1 ZAP=blah`. Each of these will be expanded into a formatted
-  option to docker of the form `--env FOO=VALUE`.
-- Enable seamless nested docker-in-docker support by bind-mounting the docker socket into the the container.
+- Accept a list of environment variables which should be exported into the underlying docker_compose run command. Each
+  of these variables will be expanded in-place by ebash using `expand_vars`. As such the variables can be a simple list
+  of env variables to export as in `FOO BAR ZAP` or they can point to other variables as in `FOO=PWD BAR ZAP` or they
+  can point to string literals as in `FOO=/home/marshall BAR=1 ZAP=blah`. Each of these will be expanded into a
+  formatted option and stored in an environment file that docker_compose will use.
 - Create ephemeral docker volumes and copy a specified local path into the docker volume and attach that volume to the
-  running docker container. This is useful for running with a DOCKER_HOST which points to an external docker server.
-- Automatically determine what value to use for --interactive.
+  running docker containers. This is useful for running with a DOCKER_HOST which points to an external docker server.
+- Automatically copy files into or out of the ephemeral docker volumes.
+- Wait for the docker composed containers to be in a ready state.
+- Tail the logs from the docker composed containers.
+- Automatically teardown the docker composed containers safely and also remove the volumes.
 END
-docker_compose()
+docker_compose_run()
 {
     $(opt_parse \
-        ":envlist                           | List of environment variables to pass into lowever level docker run. These
-                                              will be sorted before passing them into docker for better testability and
-                                              consistency."                                                            \
         "&copy_to_volume                    | Copy the specified path into a volume which is attached to the docker run
                                               instance. This is useful when running with a remote DOCKER_HOST where a
                                               simple bind mount does not work. This is also safe to use when running
@@ -832,10 +843,34 @@ docker_compose()
                                               container. The syntax for this is name:docker_path:local_path"           \
         "&copy_from_volume_delete           | After copying all volumes back to the local site, delete any paths in this
                                               list. This is because docker cp doesn't support an exclusion mechanism." \
+        ":envlist                           | List of environment variables to pass into lowever level docker run. These
+                                              will be sorted before passing them into docker for better testability and
+                                              consistency."                                                            \
+        ":file f=docker-compose.yml         | Docker compose file to use. Defaults to docker-compose.yml"              \
+        "+follow                            | Follow the output from the docker compose launched processes on STDOUT." \
+        "+follow_json                       | Follow the output from the docker compose launched processes on STDOUT but
+                                              pretty-print the logs as JSON. This is tolerant of non-JSON output too so
+                                              that no output is lost even if it is not actually JSON."                 \
+        ":logfile=docker-compose.log        | Logfile to capture all docker-compose output into."                      \
+        ":teardown                          | Teardown code to execute after docker_compose completion to perform any
+                                              necessary cleanup. This is a useful mechanism to ensure we bring down all
+                                              containers and volumes via teardown='down --volumes --remove-orphans'"   \
+        ":verbose v=0                       | Verbosity level. This is boolean for native docker-compose but we allow
+                                              various log levels and map it to boolean values when we pass it into the
+                                              lower-level docker-compose."                                             \
+        "+wait=1                            | Wait for ready status"                                                   \
+        ":wait_delay=1s                     | How long to wait between checks for service health during wait."         \
     )
 
     # Final list of docker args we will use
-    local docker_args=()
+    local docker_args=(
+        --file "${file}"
+    )
+
+    # Dynamically map verbosity level into boolean flag
+    if [[ "${verbose}" -gt 0 ]]; then
+        docker_args+=( --verbose )
+    fi
 
     # Expand env variables as required
     if [[ -n "${envlist}" ]]; then
@@ -854,45 +889,67 @@ docker_compose()
         docker_args+=( --env-file "${envfile}" )
     fi
 
-    # Deal with all copy_to_volumes
-    local entry name parts
-    for entry in ${copy_to_volume[*]:-}; do
+    # Setup copy_to_volumes and copy_from_volume and copy_from_volume_delete
+    __docker_setup_copy_volumes --no-add-volume-to-args
 
-        array_init parts "${entry}" ":"
-        assert_eq 3 "$(array_size parts)"
-        local name=${parts[0]}
-        local lpath=${parts[1]}
-        local rpath=${parts[2]}
+    # Setup any additional teardown traps
+    : ${teardown:="down --volumes --remove-orphans"}
+    trap_add "docker-compose ${docker_args[*]} ${teardown}"
 
-        edebug "Creating docker container for volume $(lval name lpath rpath)"
-        docker container create --name "${name}" -v "${name}:${rpath}" busybox | edebug
-        trap_add "docker volume rm ${name} |& edebug"
-        trap_add "docker rm ${name} |& edebug"
-        docker cp "${lpath}/." "${name}:${rpath}"
-    done
-
-    # Setup traps for copy_from_volume
-    for entry in ${copy_from_volume[*]:-}; do
-
-        array_init parts "${entry}" ":"
-        assert_eq 3 "$(array_size parts)"
-        local name=${parts[0]}
-        local rpath=${parts[1]}
-        local lpath=${parts[2]}
-
-        edebug "Setting trap to copy from $(lval name rpath lpath)"
-        trap_add "docker cp ${name}:${rpath}/. ${lpath}"
-    done
-
-    # Setup traps for copy_from_volume_delete
-    for entry in ${copy_from_volume_delete[*]:-}; do
-        edebug "Setting trap to delete $(lval entry) post-copy"
-        trap_add "rm --recursive --force \"${entry}\""
-    done
-
-    # Pass any other provided arguments into docker run directly.
-    docker_args+=( ${@:-} )
-
+    # Launch docker-compose in teh background and tail the logs in the foreground writing to the requested logfile.
+    # The tailing of the logfile will run in the foreground and block until the parent docker-compose job completes.
     edebug "Calling docker-compose with $(lval docker_args)"
-    docker-compose "${docker_args[@]:-}"
+    local pid
+    docker-compose "${docker_args[@]}" run ${@:-} &
+    pid=$!
+    edebug "Backgrounded docker-compose with $(lval pid)"
+
+    # If wait is requested then wait until status is ready for all containers
+    if [[ ${wait} -eq 1 ]]; then
+
+        local status service services=()
+        readarray -t services < <(docker-compose --file "${file}" ps --services)
+        einfo "Waiting for $(lval services)"
+        for service in ${services[@]}; do
+
+            einfos -n "${service}"
+
+            while true; do
+
+                # First try to look for actual Health Status. That only works if there is a HEALTHCHECK section in the
+                # docker compose file for this service. If there isn't we'll get a "Template parsing error". In which case
+                # we fallback to just checking the status.
+                status=$(docker inspect $(docker-compose --file "${file}" ps -q "${service}") | jq --raw-output '.[0].State.Health.Status')
+                edebug "$(lval service status)"
+                if [[ "${status}" == "healthy" ]]; then
+                    eend 0
+                    break
+                elif [[ "${status}" == "null" ]]; then
+                    status=$(docker inspect $(docker-compose --file "${file}" ps -q "${service}") | jq --raw-output '.[0].State.Status')
+
+                    if [[ "${status}" == "running" ]]; then
+                        eend 0
+                        break
+                    fi
+                fi
+
+                sleep "${wait_delay}"
+            done
+        done
+    fi
+
+    # Now we just block here following the logs. This will automatically exit when the parent docker-compose job exits.
+    if [[ "${follow}" -eq 1 ]]; then
+        docker-compose --file "${file}" logs --follow | tee "${logfile}"
+    elif [[ "${follow_json}" -eq 1 ]]; then
+        docker-compose --file "${file}" logs --follow | tee "${logfile}" \
+            | noansi \
+            | sed 's/.*| //' \
+            | jq -R '. as $line | try (fromjson) catch $line'
+    else
+        docker-compose --file "${file}" logs --follow > "${logfile}"
+    fi
+
+    # Wait on our backgrounded process and propogate any failure from it.
+    wait "${pid}"
 }

--- a/share/docker.sh
+++ b/share/docker.sh
@@ -909,7 +909,7 @@ docker_compose_run()
             readarray -t services < <(docker-compose --file "${file}" ps --services)
         fi
 
-        echo
+        echo >&2
         einfo "Waiting for $(lval services)"
         for service in "${services[@]}"; do
 
@@ -943,6 +943,8 @@ docker_compose_run()
             checkbox_close
 
         done
+
+        echo >&2
     fi
 
     # Optionally tail the output of a specific container

--- a/share/docker.sh
+++ b/share/docker.sh
@@ -862,7 +862,6 @@ docker_compose_run()
     # Final list of docker args we will use
     local docker_args=(
         --file "${file}"
-        --verbose
     )
 
     # Expand env variables as required
@@ -893,7 +892,7 @@ docker_compose_run()
     # The tailing of the logfile will run in the foreground and block until the parent docker-compose job completes.
     edebug "Calling docker-compose with $(lval docker_args)"
     local pid
-    docker-compose "${docker_args[@]}" run ${*:-} |& edebug &
+    docker-compose --verbose "${docker_args[@]}" run ${*:-} |& edebug &
     pid=$!
     edebug "Backgrounded docker-compose with $(lval pid)"
 
@@ -919,15 +918,12 @@ docker_compose_run()
                     # docker compose file for this service. If there isn't we'll get a "Template parsing error". In which case
                     # we fallback to just checking the status.
                     status=$(docker inspect "${id}" | jq --raw-output '.[0].State.Health.Status')
-                    edebug "$(lval service status)"
                     if [[ "${status}" == "healthy" ]]; then
-                        checkbox_close
                         break
                     elif [[ "${status}" == "null" ]]; then
                         status=$(docker inspect "${id}" | jq --raw-output '.[0].State.Status')
 
                         if [[ "${status}" == "running" ]]; then
-                            checkbox_close
                             break
                         fi
                     fi
@@ -935,6 +931,9 @@ docker_compose_run()
 
                 sleep "${wait_delay}"
             done
+
+            checkbox_close
+
         done
     fi
 

--- a/share/docker.sh
+++ b/share/docker.sh
@@ -685,6 +685,10 @@ docker_export()
     eprogress_kill
 }
 
+opt_usage __docker_setup_copy_volumes<<'END'
+__docker_setup_copy_volumes is an internal only helper function used to setup the copy-to-volume and copy-from-volume
+and copy-from-volume-delete options and traps used by both `docker_run` and `docker_compose_run`.
+END
 __docker_setup_copy_volumes()
 {
     $(opt_parse \
@@ -911,7 +915,7 @@ docker_compose_run()
 
         echo >&2
         einfo "Waiting for $(lval services)"
-        for service in "${services[@]}"; do
+        for service in ${services[*]:-}; do
 
             checkbox_open_timer "${service}"
 

--- a/tests/all_depends.etest
+++ b/tests/all_depends.etest
@@ -108,7 +108,7 @@ ETEST_install_go()
     )
 
     # Run the install script
-    ${EBASH_HOME}/install/go
+    EDEBUG=go ${EBASH_HOME}/install/go
 
     assert_commands_installed "${commands[@]}"
 }

--- a/tests/docker.etest
+++ b/tests/docker.etest
@@ -1224,8 +1224,8 @@ ETEST_docker_compose_run_envlist()
 
     etestmsg "Validating arguments (0)"
     assert_emock_called_with "docker-compose" 0 \
-        --file docker-compose.yml               \
         --verbose                               \
+        --file docker-compose.yml               \
         --env-file "tmp/file1"                  \
         run
 
@@ -1248,8 +1248,8 @@ ETEST_docker_compose_run_file()
 
     etestmsg "Validating arguments (0)"
     assert_emock_called_with "docker-compose" 0 \
-        --file foo.yml                          \
         --verbose                               \
+        --file foo.yml                          \
         run
 
     etestmsg "Validating args (1)"
@@ -1271,8 +1271,8 @@ ETEST_docker_compose_run_logfile()
 
     etestmsg "Validating arguments (0)"
     assert_emock_called_with "docker-compose" 0 \
-        --file docker-compose.yml               \
         --verbose                               \
+        --file docker-compose.yml               \
         run
 
     etestmsg "Validating args (1)"
@@ -1294,8 +1294,8 @@ ETEST_docker_compose_run_wait()
 
     etestmsg "Validating arguments (0)"
     assert_emock_called_with "docker-compose" 0 \
-        --file docker-compose.yml               \
         --verbose                               \
+        --file docker-compose.yml               \
         run
 
     etestmsg "Validating args (1)"
@@ -1335,8 +1335,8 @@ ETEST_docker_compose_run_wait_no_healthcheck()
 
     etestmsg "Validating arguments (0)"
     assert_emock_called_with "docker-compose" 0 \
-        --file docker-compose.yml               \
         --verbose                               \
+        --file docker-compose.yml               \
         run
 
     etestmsg "Validating args (1)"
@@ -1394,8 +1394,8 @@ ETEST_docker_compose_run_wait_with_healthcheck()
 
     etestmsg "Validating arguments (0)"
     assert_emock_called_with "docker-compose" 0 \
-        --file docker-compose.yml               \
         --verbose                               \
+        --file docker-compose.yml               \
         run
 
     etestmsg "Validating args (1)"
@@ -1437,8 +1437,8 @@ ETEST_docker_compose_run_default_wait_teardown()
 
     etestmsg "Validating arguments (0)"
     assert_emock_called_with "docker-compose" 0 \
-        --file docker-compose.yml               \
         --verbose                               \
+        --file docker-compose.yml               \
         run
 
     etestmsg "Validating args (1)"
@@ -1454,7 +1454,6 @@ ETEST_docker_compose_run_default_wait_teardown()
     etestmsg "Validating teardown args"
     assert_emock_called_with "docker-compose" 3 \
         --file docker-compose.yml               \
-        --verbose                               \
         down                                    \
         --volumes                               \
         --remove-orphans
@@ -1476,8 +1475,8 @@ ETEST_docker_compose_run_custom_wait_teardown()
 
     etestmsg "Validating arguments (0)"
     assert_emock_called_with "docker-compose" 0 \
-        --file docker-compose.yml               \
         --verbose                               \
+        --file docker-compose.yml               \
         run
 
     etestmsg "Validating args (1)"
@@ -1493,7 +1492,6 @@ ETEST_docker_compose_run_custom_wait_teardown()
     etestmsg "Validating teardown args"
     assert_emock_called_with "docker-compose" 3 \
         --file docker-compose.yml               \
-        --verbose                               \
         down                                    \
         --volumes
 }
@@ -1576,8 +1574,8 @@ ETEST_docker_compose_run_copy_to_volume()
 
     etestmsg "Validating args (0) -- docker-compose"
     assert_emock_called_with "docker-compose" 0 \
-        --file docker-compose.yml               \
         --verbose                               \
+        --file docker-compose.yml               \
         run
 }
 
@@ -1630,8 +1628,8 @@ ETEST_docker_compose_run_copy_from_volume()
 
     etestmsg "Validating arguments (0)"
     assert_emock_called_with "docker-compose" 0 \
-        --file docker-compose.yml               \
         --verbose                               \
+        --file docker-compose.yml               \
         run
 
     etestmsg "Validating args (1)"
@@ -1647,7 +1645,6 @@ ETEST_docker_compose_run_copy_from_volume()
     etestmsg "Validating teardown args"
     assert_emock_called_with "docker-compose" 3 \
         --file docker-compose.yml               \
-        --verbose                               \
         down                                    \
         --volumes                               \
         --remove-orphans
@@ -1668,8 +1665,8 @@ ETEST_docker_compose_run_passthrough_args()
 
     etestmsg "Verifying args"
     assert_emock_called_with "docker-compose" 0 \
-        --file docker-compose.yml \
         --verbose                 \
+        --file docker-compose.yml \
         run                       \
         --foo                     \
         --bar

--- a/tests/docker.etest
+++ b/tests/docker.etest
@@ -1227,7 +1227,7 @@ ETEST_docker_compose_run_envlist()
         --verbose                               \
         --file docker-compose.yml               \
         --env-file "tmp/file1"                  \
-        run
+        run -T
 }
 
 ETEST_docker_compose_run_file()
@@ -1245,7 +1245,7 @@ ETEST_docker_compose_run_file()
     assert_emock_called_with "docker-compose" 0 \
         --verbose                               \
         --file foo.yml                          \
-        run
+        run -T
 }
 
 ETEST_docker_compose_run_logfile()
@@ -1263,7 +1263,7 @@ ETEST_docker_compose_run_logfile()
     assert_emock_called_with "docker-compose" 0 \
         --verbose                               \
         --file docker-compose.yml               \
-        run
+        run -T
 }
 
 ETEST_docker_compose_run_wait()
@@ -1281,7 +1281,7 @@ ETEST_docker_compose_run_wait()
     assert_emock_called_with "docker-compose" 0 \
         --verbose                               \
         --file docker-compose.yml               \
-        run
+        run -T
 
     etestmsg "Validating args (1)"
     assert_emock_called_with "docker-compose" 1 \
@@ -1317,7 +1317,7 @@ ETEST_docker_compose_run_wait_no_healthcheck()
     assert_emock_called_with "docker-compose" 0 \
         --verbose                               \
         --file docker-compose.yml               \
-        run
+        run -T
 
     etestmsg "Validating args (1)"
     assert_emock_called_with "docker-compose" 1 \
@@ -1371,7 +1371,7 @@ ETEST_docker_compose_run_wait_with_healthcheck()
     assert_emock_called_with "docker-compose" 0 \
         --verbose                               \
         --file docker-compose.yml               \
-        run
+        run -T
 
     etestmsg "Validating args (1)"
     assert_emock_called_with "docker-compose" 1 \
@@ -1409,7 +1409,7 @@ ETEST_docker_compose_run_default_wait_teardown()
     assert_emock_called_with "docker-compose" 0 \
         --verbose                               \
         --file docker-compose.yml               \
-        run
+        run -T
 
     etestmsg "Validating args (1)"
     assert_emock_called_with "docker-compose" 1 \
@@ -1442,7 +1442,7 @@ ETEST_docker_compose_run_custom_wait_teardown()
     assert_emock_called_with "docker-compose" 0 \
         --verbose                               \
         --file docker-compose.yml               \
-        run
+        run -T
 
     etestmsg "Validating args (1)"
     assert_emock_called_with "docker-compose" 1 \
@@ -1536,7 +1536,7 @@ ETEST_docker_compose_run_copy_to_volume()
     assert_emock_called_with "docker-compose" 0 \
         --verbose                               \
         --file docker-compose.yml               \
-        run
+        run -T
 }
 
 ETEST_docker_compose_run_copy_from_volume()
@@ -1590,7 +1590,7 @@ ETEST_docker_compose_run_copy_from_volume()
     assert_emock_called_with "docker-compose" 0 \
         --verbose                               \
         --file docker-compose.yml               \
-        run
+        run -T
 
     etestmsg "Validating args (1)"
     assert_emock_called_with "docker-compose" 1 \
@@ -1622,7 +1622,7 @@ ETEST_docker_compose_run_passthrough_args()
     assert_emock_called_with "docker-compose" 0 \
         --verbose                 \
         --file docker-compose.yml \
-        run                       \
+        run -T                    \
         --foo                     \
         --bar
 }
@@ -1661,7 +1661,7 @@ ETEST_docker_compose_run_follow()
     assert_emock_called_with "docker-compose" 0 \
         --verbose                               \
         --file docker-compose.yml               \
-        run
+        run -T
 
     etestmsg "Validating args (1)"
     assert_emock_called_with "docker-compose" 1 \
@@ -1727,7 +1727,7 @@ ETEST_docker_compose_run_follow_json()
     assert_emock_called_with "docker-compose" 0 \
         --verbose                               \
         --file docker-compose.yml               \
-        run
+        run -T
 
     etestmsg "Validating args (1)"
     assert_emock_called_with "docker-compose" 1 \

--- a/tests/docker.etest
+++ b/tests/docker.etest
@@ -27,6 +27,7 @@ docker()
 setup()
 {
     docker_tags_pushed=()
+    EDEBUG+=" docker"
 }
 
 ETEST_docker_build()
@@ -1015,7 +1016,7 @@ ETEST_docker_run_envlist()
     etestmsg "Calling docker_run with env list"
     docker_run --interactive=no --envlist 'FOO BAR ZAP DAB BLAH=PATH ARG=1 ARG2="Another with spaces"'
 
-    etestmsg "Verifying mock called expected number of times"
+    etestmsg "Verifying docker called expected number of times"
     assert_emock_called "docker" 1
 
     etestmsg "Validating arguments"
@@ -1036,7 +1037,7 @@ ETEST_docker_run_nested()
     etestmsg "Calling docker_run with --nested"
     docker_run --interactive=no --nested
 
-    etestmsg "Verifying mock called expected number of times"
+    etestmsg "Verifying docker called expected number of times"
     assert_emock_called "docker" 1
 
     etestmsg "Validating arguments"
@@ -1058,7 +1059,7 @@ ETEST_docker_run_copy_to_volume()
             --copy-to-volume "ebash:/home/ebash:/baggins"      \
     )
 
-    etestmsg "Verifying mock called 13 times"
+    etestmsg "Verifying docker called 13 times"
     assert_emock_called "docker" 13
 
     etestmsg "Validating arguments (0) -- container create"
@@ -1148,7 +1149,7 @@ ETEST_docker_run_copy_from_volume()
             --copy-from-volume-delete "/home/baggins/trash"      \
     )
 
-    etestmsg "Verifying mock called 4 times"
+    etestmsg "Verifying docker called 4 times"
     assert_emock_called "docker" 4
 
     etestmsg "Validating args (0) -- docker run"
@@ -1189,7 +1190,7 @@ ETEST_docker_run_passthrough_args()
         --rm            \
         --workdir /ebash
 
-    etestmsg "Verifying mock called 1 times"
+    etestmsg "Verifying docker called 1 times"
     assert_emock_called "docker" 1
 
     etestmsg "Verifying args"
@@ -1203,7 +1204,7 @@ ETEST_docker_run_passthrough_args()
         --workdir /ebash
 }
 
-ETEST_docker_compose_envlist()
+ETEST_docker_compose_run_envlist()
 {
     emock --stdout "tmp/file1" "mktemp"
     emock "docker-compose"
@@ -1215,35 +1216,299 @@ ETEST_docker_compose_envlist()
     ZAP="This one has spaces in it"
     DAB="${PATH}"
 
-    etestmsg "Calling docker_compose with env list"
-    docker_compose --envlist 'FOO BAR ZAP DAB BLAH=PATH ARG=1 ARG2="Another with spaces"'
+    etestmsg "Calling docker_compose_run with env list"
+    docker_compose_run --no-wait --envlist 'FOO BAR ZAP DAB BLAH=PATH ARG=1 ARG2="Another with spaces"'
 
-    etestmsg "Verifying mock called expected number of times"
-    assert_emock_called "docker-compose" 1
+    etestmsg "Verifying docker-compose called expected number of times"
+    assert_emock_called "docker-compose" 2
 
-    etestmsg "Validating arguments"
+    etestmsg "Validating arguments (0)"
     assert_emock_called_with "docker-compose" 0 \
-        --env-file "tmp/file1"
+        --file docker-compose.yml               \
+        --env-file "tmp/file1"                  \
+        run
+
+    etestmsg "Validating arguments (1)"
+    assert_emock_called_with "docker-compose" 1 \
+        --file docker-compose.yml               \
+        logs --follow
 }
 
-ETEST_docker_compose_copy_to_volume()
+ETEST_docker_compose_run_file()
+{
+    emock "docker-compose"
+
+    etestmsg "Calling docker_compose_run with --file"
+
+    docker_compose_run --no-wait --file "foo.yml"
+
+    etestmsg "Verifying docker-compose called expected number of times"
+    assert_emock_called "docker-compose" 2
+
+    etestmsg "Validating arguments (0)"
+    assert_emock_called_with "docker-compose" 0 \
+        --file foo.yml                          \
+        run
+
+    etestmsg "Validating args (1)"
+    assert_emock_called_with "docker-compose" 1 \
+        --file foo.yml                          \
+        logs --follow
+}
+
+ETEST_docker_compose_run_logfile()
+{
+    emock "docker-compose"
+
+    etestmsg "Calling docker_compose_run with logfile"
+
+    docker_compose_run --no-wait --logfile foo.log
+
+    etestmsg "Verifying docker-compose called expected number of times"
+    assert_emock_called "docker-compose" 2
+
+    etestmsg "Validating arguments (0)"
+    assert_emock_called_with "docker-compose" 0 \
+        --file docker-compose.yml               \
+        run
+
+    etestmsg "Validating args (1)"
+    assert_emock_called_with "docker-compose" 1 \
+        --file docker-compose.yml               \
+        logs --follow
+}
+
+ETEST_docker_compose_run_wait()
+{
+    emock "docker-compose"
+
+    etestmsg "Calling docker_compose_run with --wait"
+
+    docker_compose_run --wait
+
+    etestmsg "Verifying docker-compose called expected number of times"
+    assert_emock_called "docker-compose" 3
+
+    etestmsg "Validating arguments (0)"
+    assert_emock_called_with "docker-compose" 0 \
+        --file docker-compose.yml               \
+        run
+
+    etestmsg "Validating args (1)"
+    assert_emock_called_with "docker-compose" 1 \
+        --file docker-compose.yml               \
+        ps --services
+
+    etestmsg "Validating args (2)"
+    assert_emock_called_with "docker-compose" 2 \
+        --file docker-compose.yml               \
+        logs --follow
+}
+
+ETEST_docker_compose_run_wait_no_healthcheck()
+{
+    emock "docker-compose" '
+    {
+        if [[ ${called} -eq 1 ]]; then
+            echo "minio"
+        else
+            echo ""
+        fi
+    }'
+
+    emock "docker" '
+    {
+        if [[ $1 == "inspect" ]]; then
+            echo "[{\"State\": {\"Status\": \"running\"}}]"
+        fi
+    }'
+
+    etestmsg "Calling docker_compose_run with --wait"
+    docker_compose_run --wait
+
+    etestmsg "Verifying docker-compose called expected number of times"
+    assert_emock_called "docker-compose" 5
+
+    etestmsg "Validating arguments (0)"
+    assert_emock_called_with "docker-compose" 0 \
+        --file docker-compose.yml               \
+        run
+
+    etestmsg "Validating args (1)"
+    assert_emock_called_with "docker-compose" 1 \
+        --file docker-compose.yml               \
+        ps --services
+
+    etestmsg "Validating args (2)"
+    assert_emock_called_with "docker-compose" 2 \
+        --file docker-compose.yml               \
+        ps -q minio
+
+    etestmsg "Validating args (3)"
+    assert_emock_called_with "docker-compose" 3 \
+        --file docker-compose.yml               \
+        ps -q minio
+
+    etestmsg "Validating args (4)"
+    assert_emock_called_with "docker-compose" 4 \
+        --file docker-compose.yml               \
+        logs --follow
+
+    etestmsg "Verifying docker called expected number of times"
+    assert_emock_called "docker" 2
+
+    etestmsg "Validating arguments (0)"
+    assert_emock_called_with "docker" 0 \
+        inspect
+
+    etestmsg "Validating args (1)"
+    assert_emock_called_with "docker" 1 \
+        inspect
+}
+
+ETEST_docker_compose_run_wait_with_healthcheck()
+{
+    emock "docker-compose" '
+    {
+        if [[ ${called} -eq 1 ]]; then
+            echo "minio"
+        else
+            echo ""
+        fi
+    }'
+
+    emock "docker" '
+    {
+        if [[ ${called} -eq 0 ]]; then
+            echo "[{\"State\": {\"Health\": {\"Status\": \"healthy\"}}}]"
+        else
+            echo "[{\"State\": {\"Status\": \"running\"}}]"
+        fi
+    }'
+
+    etestmsg "Calling docker_compose_run with --wait"
+    docker_compose_run --wait
+
+    etestmsg "Verifying docker-compose called expected number of times"
+    assert_emock_called "docker-compose" 4
+
+    etestmsg "Validating arguments (0)"
+    assert_emock_called_with "docker-compose" 0 \
+        --file docker-compose.yml               \
+        run
+
+    etestmsg "Validating args (1)"
+    assert_emock_called_with "docker-compose" 1 \
+        --file docker-compose.yml               \
+        ps --services
+
+    etestmsg "Validating args (2)"
+    assert_emock_called_with "docker-compose" 2 \
+        --file docker-compose.yml               \
+        ps -q minio
+
+    etestmsg "Validating args (3)"
+    assert_emock_called_with "docker-compose" 3 \
+        --file docker-compose.yml               \
+        logs --follow
+
+    etestmsg "Verifying docker called expected number of times"
+    assert_emock_called "docker" 1
+
+    etestmsg "Validating arguments (0)"
+    assert_emock_called_with "docker" 0 \
+        inspect
+}
+
+ETEST_docker_compose_run_default_wait_teardown()
+{
+    emock "docker-compose"
+
+    etestmsg "Calling docker_compose_run with default --wait and --teardown"
+
+    # Run this inside a subshell so that we can ensure the traps are getting called to remove the ephemeral volumes
+    (
+        docker_compose_run
+    )
+
+    etestmsg "Verifying docker-compose called expected number of times"
+    assert_emock_called "docker-compose" 4
+
+    etestmsg "Validating arguments (0)"
+    assert_emock_called_with "docker-compose" 0 \
+        --file docker-compose.yml               \
+        run
+
+    etestmsg "Validating args (1)"
+    assert_emock_called_with "docker-compose" 1 \
+        --file docker-compose.yml               \
+        ps --services
+
+    etestmsg "Validating args (2)"
+    assert_emock_called_with "docker-compose" 2 \
+        --file docker-compose.yml               \
+        logs --follow
+
+    etestmsg "Validating teardown args"
+    assert_emock_called_with "docker-compose" 3 \
+        --file docker-compose.yml               \
+        down                                    \
+        --volumes                               \
+        --remove-orphans
+}
+
+ETEST_docker_compose_run_custom_wait_teardown()
+{
+    emock "docker-compose"
+
+    etestmsg "Calling docker_compose_run with --wait and custom --teardown"
+
+    # Run this inside a subshell so that we can ensure the traps are getting called to remove the ephemeral volumes
+    (
+        docker_compose_run --teardown "down --volumes"
+    )
+
+    etestmsg "Verifying docker-compose called expected number of times"
+    assert_emock_called "docker-compose" 4
+
+    etestmsg "Validating arguments (0)"
+    assert_emock_called_with "docker-compose" 0 \
+        --file docker-compose.yml               \
+        run
+
+    etestmsg "Validating args (1)"
+    assert_emock_called_with "docker-compose" 1 \
+        --file docker-compose.yml               \
+        ps --services
+
+    etestmsg "Validating args (2)"
+    assert_emock_called_with "docker-compose" 2 \
+        --file docker-compose.yml               \
+        logs --follow
+
+    etestmsg "Validating teardown args"
+    assert_emock_called_with "docker-compose" 3 \
+        --file docker-compose.yml               \
+        down                                    \
+        --volumes
+}
+
+ETEST_docker_compose_run_copy_to_volume()
 {
     emock "docker"
     emock "docker-compose"
 
-    etestmsg "Calling docker_compose with multiple copy_to_volume"
+    etestmsg "Calling docker_compose_run with multiple copy_to_volume"
 
     # Run this inside a subshell so that we can ensure the traps are getting called to remove the ephemeral volumes
     (
-        docker_compose                                         \
+        docker_compose_run                                     \
             --copy-to-volume "foo:foo:/foo"                    \
             --copy-to-volume "data:/home/marshall/data:/data"  \
             --copy-to-volume "ebash:/home/ebash:/baggins"      \
-            --                                                 \
-            up
     )
 
-    etestmsg "Verifying docker called 12 times"
+    etestmsg "Verifying docker called expected number of times"
     assert_emock_called "docker" 12
 
     etestmsg "Validating arguments (0) -- container create"
@@ -1306,10 +1571,11 @@ ETEST_docker_compose_copy_to_volume()
 
     etestmsg "Validating args (0) -- docker-compose"
     assert_emock_called_with "docker-compose" 0 \
-        up
+        --file docker-compose.yml               \
+        run
 }
 
-ETEST_docker_compose_copy_from_volume()
+ETEST_docker_compose_run_copy_from_volume()
 {
     emock "docker"
     trap_add "eunmock docker"
@@ -1319,21 +1585,19 @@ ETEST_docker_compose_copy_from_volume()
     emock "rm"
     trap_add "eunmock rm"
 
-    etestmsg "Calling docker_compose with multiple copy_from_volume"
+    etestmsg "Calling docker_compose_run with multiple copy_from_volume"
 
     # Run this inside a subshell so that we can ensure the traps are getting called to remove the ephemeral volumes
     (
-        docker_compose                                           \
+        docker_compose_run                                       \
             --copy-from-volume "foo:/foo:foo"                    \
             --copy-from-volume-delete "foo/bad"                  \
             --copy-from-volume "data:/home/marshall/data:data"   \
             --copy-from-volume "ebash:/home/ebash:/home/baggins" \
             --copy-from-volume-delete "/home/baggins/trash"      \
-            --                                                   \
-            up
     )
 
-    etestmsg "Verifying mock called 3 times"
+    etestmsg "Verifying docker called expected number of times"
     assert_emock_called "docker" 3
 
     etestmsg "Validating args (0) -- docker cp"
@@ -1355,30 +1619,145 @@ ETEST_docker_compose_copy_from_volume()
     assert_emock_called_with "rm" 1 \
         --recursive --force "foo/bad"
 
-    etestmsg "Validating args (0) -- docker-compose"
+    etestmsg "Verifying docker-compose called expected number of times"
+    assert_emock_called "docker-compose" 4
+
+    etestmsg "Validating arguments (0)"
     assert_emock_called_with "docker-compose" 0 \
-        up
+        --file docker-compose.yml               \
+        run
+
+    etestmsg "Validating args (1)"
+    assert_emock_called_with "docker-compose" 1 \
+        --file docker-compose.yml               \
+        ps --services
+
+    etestmsg "Validating args (2)"
+    assert_emock_called_with "docker-compose" 2 \
+        --file docker-compose.yml               \
+        logs --follow
+
+    etestmsg "Validating teardown args"
+    assert_emock_called_with "docker-compose" 3 \
+        --file docker-compose.yml               \
+        down                                    \
+        --volumes                               \
+        --remove-orphans
 }
 
-ETEST_docker_compose_passthrough_args()
+ETEST_docker_compose_run_passthrough_args()
 {
     emock "docker-compose"
 
-    etestmsg "Calling docker_compose with passthrough args"
+    etestmsg "Calling docker_compose_run with passthrough args"
 
-    docker_compose   -- \
-        --file some.yml \
-        --verbose       \
-        --no-ansi       \
-        up
+    docker_compose_run --no-wait -- \
+        --foo                       \
+        --bar
 
-    etestmsg "Verifying mock called 1 times"
-    assert_emock_called "docker-compose" 1
+    etestmsg "Verifying docker-compose called expected number of times"
+    assert_emock_called "docker-compose" 2
 
     etestmsg "Verifying args"
     assert_emock_called_with "docker-compose" 0 \
-        --file some.yml \
-        --verbose       \
-        --no-ansi       \
-        up
+        --file docker-compose.yml \
+        run                       \
+        --foo                     \
+        --bar
+}
+
+ETEST_docker_compose_run_verbose_value()
+{
+    emock "docker-compose"
+
+    etestmsg "Calling docker_compose_run with --verbose=1"
+
+    docker_compose_run --no-wait --verbose=5
+
+    etestmsg "Verifying docker-compose called expected number of times"
+    assert_emock_called "docker-compose" 2
+
+    etestmsg "Verifying args"
+    assert_emock_called_with "docker-compose" 0 \
+        --file docker-compose.yml \
+        --verbose                 \
+        run
+
+    etestmsg "Validating args (2)"
+    assert_emock_called_with "docker-compose" 1 \
+        --file docker-compose.yml               \
+        logs --follow
+}
+
+ETEST_docker_compose_run_follow()
+{
+    etestmsg "Expected output"
+	cat <<-END >expect
+	Attaching to docker_ServiceA_1, docker_ServiceB_1, docker_ServiceB-testdata_1, docker_ServiceA-migrations_1
+	ServiceA_1 | INSERT 0 1
+	ServiceB_1 | {"level":"info","msg":"Starting up server","service":"ServiceA","time":"2022-02-10T00:41:53Z"}
+	END
+    cat expect
+
+    emock "docker-compose" '
+    {
+        if [[ ${called} -eq 1 ]]; then
+            cat expect
+        fi
+    }'
+
+    etestmsg "Calling docker_compose_run with --follow"
+    docker_compose_run --no-wait --follow > actual
+
+    etestmsg "Verifying docker-compose called expected number of times"
+    assert_emock_called "docker-compose" 2
+
+    etestmsg "Actual Output"
+    cat actual
+
+    etestmsg "Diff"
+    diff -u expect actual
+}
+
+ETEST_docker_compose_run_follow_json()
+{
+    etestmsg "Raw output"
+	cat <<-END >raw
+	Attaching to docker_ServiceA_1, docker_ServiceB_1, docker_ServiceB-testdata_1, docker_ServiceA-migrations_1
+	ServiceA_1 | INSERT 0 1
+	SerivceB_1 | {"level":"info","msg":"Starting up server","service":"ServiceA","time":"2022-02-10T00:41:53Z"}
+	END
+    cat raw
+
+    etestmsg "Expected formatted output"
+	cat <<-END >expect
+	"Attaching to docker_ServiceA_1, docker_ServiceB_1, docker_ServiceB-testdata_1, docker_ServiceA-migrations_1"
+	"INSERT 0 1"
+	{
+	  "level": "info",
+	  "msg": "Starting up server",
+	  "service": "ServiceA",
+	  "time": "2022-02-10T00:41:53Z"
+	}
+	END
+    cat expect
+
+    emock "docker-compose" '
+    {
+        if [[ ${called} -eq 1 ]]; then
+            cat raw
+        fi
+    }'
+
+    etestmsg "Calling docker_compose_run with --follow-json"
+    docker_compose_run --no-wait --follow-json > actual
+
+    etestmsg "Verifying docker-compose called expected number of times"
+    assert_emock_called "docker-compose" 2
+
+    etestmsg "Actual Output"
+    cat actual
+
+    etestmsg "Diff"
+    diff -u expect actual
 }

--- a/tests/docker.etest
+++ b/tests/docker.etest
@@ -1202,3 +1202,183 @@ ETEST_docker_run_passthrough_args()
         --rm            \
         --workdir /ebash
 }
+
+ETEST_docker_compose_envlist()
+{
+    emock --stdout "tmp/file1" "mktemp"
+    emock "docker-compose"
+
+    # Set some environment variables we want to pass through into docker
+    etestmsg "Creating dummy variables"
+    FOO=1
+    BAR=2
+    ZAP="This one has spaces in it"
+    DAB="${PATH}"
+
+    etestmsg "Calling docker_compose with env list"
+    docker_compose --envlist 'FOO BAR ZAP DAB BLAH=PATH ARG=1 ARG2="Another with spaces"'
+
+    etestmsg "Verifying mock called expected number of times"
+    assert_emock_called "docker-compose" 1
+
+    etestmsg "Validating arguments"
+    assert_emock_called_with "docker-compose" 0 \
+        --env-file "tmp/file1"
+}
+
+ETEST_docker_compose_copy_to_volume()
+{
+    emock "docker"
+    emock "docker-compose"
+
+    etestmsg "Calling docker_compose with multiple copy_to_volume"
+
+    # Run this inside a subshell so that we can ensure the traps are getting called to remove the ephemeral volumes
+    (
+        docker_compose                                         \
+            --copy-to-volume "foo:foo:/foo"                    \
+            --copy-to-volume "data:/home/marshall/data:/data"  \
+            --copy-to-volume "ebash:/home/ebash:/baggins"      \
+            --                                                 \
+            up
+    )
+
+    etestmsg "Verifying docker called 12 times"
+    assert_emock_called "docker" 12
+
+    etestmsg "Validating arguments (0) -- container create"
+    assert_emock_called_with "docker" 0 \
+        container create        \
+        --name foo              \
+        -v foo:/foo             \
+        busybox
+
+    etestmsg "Validating args (1) -- docker cp"
+    assert_emock_called_with "docker" 1 \
+        cp "foo/."              \
+        "foo:/foo"
+
+    etestmsg "Validating arguments (2) -- container create"
+    assert_emock_called_with "docker" 2 \
+        container create        \
+        --name data             \
+        -v data:/data           \
+        busybox
+
+    etestmsg "Validating args (3) -- docker cp"
+    assert_emock_called_with "docker" 3 \
+        cp "/home/marshall/data/." "data:/data"
+
+    etestmsg "Validating arguments (4) -- container create"
+    assert_emock_called_with "docker" 4 \
+        container create        \
+        --name ebash            \
+        -v ebash:/baggins       \
+        busybox
+
+    etestmsg "Validating args (5) -- docker cp"
+    assert_emock_called_with "docker" 5 \
+        cp "/home/ebash/." "ebash:/baggins"
+
+    etestmsg "Validating args (6) -- docker rm"
+    assert_emock_called_with "docker" 6 \
+        rm ebash
+
+    etestmsg "Validating args (7) -- docker volume rm"
+    assert_emock_called_with "docker" 7 \
+        volume rm ebash
+
+    etestmsg "Validating args (8) -- docker rm"
+    assert_emock_called_with "docker" 8 \
+        rm data
+
+    etestmsg "Validating args (9) -- docker volume rm"
+    assert_emock_called_with "docker" 9 \
+        volume rm data
+
+    etestmsg "Validating args (10) -- docker rm"
+    assert_emock_called_with "docker" 10 \
+        rm foo
+
+    etestmsg "Validating args (11) -- docker volume rm"
+    assert_emock_called_with "docker" 11 \
+        volume rm foo
+
+    etestmsg "Validating args (0) -- docker-compose"
+    assert_emock_called_with "docker-compose" 0 \
+        up
+}
+
+ETEST_docker_compose_copy_from_volume()
+{
+    emock "docker"
+    trap_add "eunmock docker"
+    emock "docker-compose"
+    trap_add "eunmock docker-compose"
+
+    emock "rm"
+    trap_add "eunmock rm"
+
+    etestmsg "Calling docker_compose with multiple copy_from_volume"
+
+    # Run this inside a subshell so that we can ensure the traps are getting called to remove the ephemeral volumes
+    (
+        docker_compose                                           \
+            --copy-from-volume "foo:/foo:foo"                    \
+            --copy-from-volume-delete "foo/bad"                  \
+            --copy-from-volume "data:/home/marshall/data:data"   \
+            --copy-from-volume "ebash:/home/ebash:/home/baggins" \
+            --copy-from-volume-delete "/home/baggins/trash"      \
+            --                                                   \
+            up
+    )
+
+    etestmsg "Verifying mock called 3 times"
+    assert_emock_called "docker" 3
+
+    etestmsg "Validating args (0) -- docker cp"
+    assert_emock_called_with "docker" 0 \
+        cp "ebash:/home/ebash/." "/home/baggins"
+
+    etestmsg "Validating args (1) -- docker cp"
+    assert_emock_called_with "docker" 1 \
+        cp "data:/home/marshall/data/." "data"
+
+    etestmsg "Validating args (2) -- docker cp"
+    assert_emock_called_with "docker" 2 \
+        cp "foo:/foo/." "foo"
+
+    etestmsg "Verifying post-copy deletes called"
+    assert_emock_called "rm" 2
+    assert_emock_called_with "rm" 0 \
+        --recursive --force "/home/baggins/trash"
+    assert_emock_called_with "rm" 1 \
+        --recursive --force "foo/bad"
+
+    etestmsg "Validating args (0) -- docker-compose"
+    assert_emock_called_with "docker-compose" 0 \
+        up
+}
+
+ETEST_docker_compose_passthrough_args()
+{
+    emock "docker-compose"
+
+    etestmsg "Calling docker_compose with passthrough args"
+
+    docker_compose   -- \
+        --file some.yml \
+        --verbose       \
+        --no-ansi       \
+        up
+
+    etestmsg "Verifying mock called 1 times"
+    assert_emock_called "docker-compose" 1
+
+    etestmsg "Verifying args"
+    assert_emock_called_with "docker-compose" 0 \
+        --file some.yml \
+        --verbose       \
+        --no-ansi       \
+        up
+}

--- a/tests/docker.etest
+++ b/tests/docker.etest
@@ -1220,7 +1220,7 @@ ETEST_docker_compose_run_envlist()
     docker_compose_run --no-wait --envlist 'FOO BAR ZAP DAB BLAH=PATH ARG=1 ARG2="Another with spaces"'
 
     etestmsg "Verifying docker-compose called expected number of times"
-    assert_emock_called "docker-compose" 2
+    assert_emock_called "docker-compose" 1
 
     etestmsg "Validating arguments (0)"
     assert_emock_called_with "docker-compose" 0 \
@@ -1228,11 +1228,6 @@ ETEST_docker_compose_run_envlist()
         --file docker-compose.yml               \
         --env-file "tmp/file1"                  \
         run
-
-    etestmsg "Validating arguments (1)"
-    assert_emock_called_with "docker-compose" 1 \
-        --file docker-compose.yml               \
-        logs --follow
 }
 
 ETEST_docker_compose_run_file()
@@ -1244,18 +1239,13 @@ ETEST_docker_compose_run_file()
     docker_compose_run --no-wait --file "foo.yml"
 
     etestmsg "Verifying docker-compose called expected number of times"
-    assert_emock_called "docker-compose" 2
+    assert_emock_called "docker-compose" 1
 
     etestmsg "Validating arguments (0)"
     assert_emock_called_with "docker-compose" 0 \
         --verbose                               \
         --file foo.yml                          \
         run
-
-    etestmsg "Validating args (1)"
-    assert_emock_called_with "docker-compose" 1 \
-        --file foo.yml                          \
-        logs --follow
 }
 
 ETEST_docker_compose_run_logfile()
@@ -1267,18 +1257,13 @@ ETEST_docker_compose_run_logfile()
     docker_compose_run --no-wait --logfile foo.log
 
     etestmsg "Verifying docker-compose called expected number of times"
-    assert_emock_called "docker-compose" 2
+    assert_emock_called "docker-compose" 1
 
     etestmsg "Validating arguments (0)"
     assert_emock_called_with "docker-compose" 0 \
         --verbose                               \
         --file docker-compose.yml               \
         run
-
-    etestmsg "Validating args (1)"
-    assert_emock_called_with "docker-compose" 1 \
-        --file docker-compose.yml               \
-        logs --follow
 }
 
 ETEST_docker_compose_run_wait()
@@ -1290,7 +1275,7 @@ ETEST_docker_compose_run_wait()
     docker_compose_run --wait
 
     etestmsg "Verifying docker-compose called expected number of times"
-    assert_emock_called "docker-compose" 3
+    assert_emock_called "docker-compose" 2
 
     etestmsg "Validating arguments (0)"
     assert_emock_called_with "docker-compose" 0 \
@@ -1302,11 +1287,6 @@ ETEST_docker_compose_run_wait()
     assert_emock_called_with "docker-compose" 1 \
         --file docker-compose.yml               \
         ps --services
-
-    etestmsg "Validating args (2)"
-    assert_emock_called_with "docker-compose" 2 \
-        --file docker-compose.yml               \
-        logs --follow
 }
 
 ETEST_docker_compose_run_wait_no_healthcheck()
@@ -1331,7 +1311,7 @@ ETEST_docker_compose_run_wait_no_healthcheck()
     docker_compose_run --wait
 
     etestmsg "Verifying docker-compose called expected number of times"
-    assert_emock_called "docker-compose" 4
+    assert_emock_called "docker-compose" 3
 
     etestmsg "Validating arguments (0)"
     assert_emock_called_with "docker-compose" 0 \
@@ -1348,11 +1328,6 @@ ETEST_docker_compose_run_wait_no_healthcheck()
     assert_emock_called_with "docker-compose" 2 \
         --file docker-compose.yml               \
         ps -q minio
-
-    etestmsg "Validating args (3)"
-    assert_emock_called_with "docker-compose" 3 \
-        --file docker-compose.yml               \
-        logs --follow
 
     etestmsg "Verifying docker called expected number of times"
     assert_emock_called "docker" 2
@@ -1390,7 +1365,7 @@ ETEST_docker_compose_run_wait_with_healthcheck()
     docker_compose_run --wait
 
     etestmsg "Verifying docker-compose called expected number of times"
-    assert_emock_called "docker-compose" 4
+    assert_emock_called "docker-compose" 3
 
     etestmsg "Validating arguments (0)"
     assert_emock_called_with "docker-compose" 0 \
@@ -1407,11 +1382,6 @@ ETEST_docker_compose_run_wait_with_healthcheck()
     assert_emock_called_with "docker-compose" 2 \
         --file docker-compose.yml               \
         ps -q minio
-
-    etestmsg "Validating args (3)"
-    assert_emock_called_with "docker-compose" 3 \
-        --file docker-compose.yml               \
-        logs --follow
 
     etestmsg "Verifying docker called expected number of times"
     assert_emock_called "docker" 1
@@ -1433,7 +1403,7 @@ ETEST_docker_compose_run_default_wait_teardown()
     )
 
     etestmsg "Verifying docker-compose called expected number of times"
-    assert_emock_called "docker-compose" 4
+    assert_emock_called "docker-compose" 3
 
     etestmsg "Validating arguments (0)"
     assert_emock_called_with "docker-compose" 0 \
@@ -1446,13 +1416,8 @@ ETEST_docker_compose_run_default_wait_teardown()
         --file docker-compose.yml               \
         ps --services
 
-    etestmsg "Validating args (2)"
-    assert_emock_called_with "docker-compose" 2 \
-        --file docker-compose.yml               \
-        logs --follow
-
     etestmsg "Validating teardown args"
-    assert_emock_called_with "docker-compose" 3 \
+    assert_emock_called_with "docker-compose" 2 \
         --file docker-compose.yml               \
         down                                    \
         --volumes                               \
@@ -1471,7 +1436,7 @@ ETEST_docker_compose_run_custom_wait_teardown()
     )
 
     etestmsg "Verifying docker-compose called expected number of times"
-    assert_emock_called "docker-compose" 4
+    assert_emock_called "docker-compose" 3
 
     etestmsg "Validating arguments (0)"
     assert_emock_called_with "docker-compose" 0 \
@@ -1484,13 +1449,8 @@ ETEST_docker_compose_run_custom_wait_teardown()
         --file docker-compose.yml               \
         ps --services
 
-    etestmsg "Validating args (2)"
-    assert_emock_called_with "docker-compose" 2 \
-        --file docker-compose.yml               \
-        logs --follow
-
     etestmsg "Validating teardown args"
-    assert_emock_called_with "docker-compose" 3 \
+    assert_emock_called_with "docker-compose" 2 \
         --file docker-compose.yml               \
         down                                    \
         --volumes
@@ -1624,7 +1584,7 @@ ETEST_docker_compose_run_copy_from_volume()
         --recursive --force "foo/bad"
 
     etestmsg "Verifying docker-compose called expected number of times"
-    assert_emock_called "docker-compose" 4
+    assert_emock_called "docker-compose" 3
 
     etestmsg "Validating arguments (0)"
     assert_emock_called_with "docker-compose" 0 \
@@ -1637,13 +1597,8 @@ ETEST_docker_compose_run_copy_from_volume()
         --file docker-compose.yml               \
         ps --services
 
-    etestmsg "Validating args (2)"
-    assert_emock_called_with "docker-compose" 2 \
-        --file docker-compose.yml               \
-        logs --follow
-
     etestmsg "Validating teardown args"
-    assert_emock_called_with "docker-compose" 3 \
+    assert_emock_called_with "docker-compose" 2 \
         --file docker-compose.yml               \
         down                                    \
         --volumes                               \
@@ -1661,7 +1616,7 @@ ETEST_docker_compose_run_passthrough_args()
         --bar
 
     etestmsg "Verifying docker-compose called expected number of times"
-    assert_emock_called "docker-compose" 2
+    assert_emock_called "docker-compose" 1
 
     etestmsg "Verifying args"
     assert_emock_called_with "docker-compose" 0 \
@@ -1674,26 +1629,51 @@ ETEST_docker_compose_run_passthrough_args()
 
 ETEST_docker_compose_run_follow()
 {
-    etestmsg "Expected output"
-	cat <<-END >expect
-	Attaching to docker_ServiceA_1, docker_ServiceB_1, docker_ServiceB-testdata_1, docker_ServiceA-migrations_1
-	ServiceA_1 | INSERT 0 1
-	ServiceB_1 | {"level":"info","msg":"Starting up server","service":"ServiceA","time":"2022-02-10T00:41:53Z"}
-	END
-    cat expect
-
     emock "docker-compose" '
     {
-        if [[ ${called} -eq 1 ]]; then
+        if [[ ${called} -eq 0 ]]; then
+            echo ""
+        else
+            echo "42"
+        fi
+    }'
+
+    emock "docker" '
+    {
+        if [[ $1 == "logs" ]]; then
             cat expect
         fi
     }'
 
-    etestmsg "Calling docker_compose_run with --follow"
-    docker_compose_run --no-wait --follow > actual
+    etestmsg "Expected output"
+	cat <<-END >expect
+	{"level":"info","msg":"Starting up server","service":"ServiceA","time":"2022-02-10T00:41:53Z"}
+	END
+    cat expect
+
+    etestmsg "Calling docker_compose_run with --follow ServiceA"
+    docker_compose_run --no-wait --follow ServiceA > actual
 
     etestmsg "Verifying docker-compose called expected number of times"
     assert_emock_called "docker-compose" 2
+
+    etestmsg "Validating args (0)"
+    assert_emock_called_with "docker-compose" 0 \
+        --verbose                               \
+        --file docker-compose.yml               \
+        run
+
+    etestmsg "Validating args (1)"
+    assert_emock_called_with "docker-compose" 1 \
+        --file docker-compose.yml               \
+        ps -q ServiceA
+
+    etestmsg "Verifying docker called expected number of times"
+    assert_emock_called "docker" 1
+
+    etestmsg "Validating args (1)"
+    assert_emock_called_with "docker" 0 \
+        logs 42 --follow
 
     etestmsg "Actual Output"
     cat actual
@@ -1704,18 +1684,30 @@ ETEST_docker_compose_run_follow()
 
 ETEST_docker_compose_run_follow_json()
 {
+    emock "docker-compose" '
+    {
+        if [[ ${called} -eq 0 ]]; then
+            echo ""
+        else
+            echo "42"
+        fi
+    }'
+
+    emock "docker" '
+    {
+        if [[ $1 == "logs" ]]; then
+            cat raw
+        fi
+    }'
+
     etestmsg "Raw output"
 	cat <<-END >raw
-	Attaching to docker_ServiceA_1, docker_ServiceB_1, docker_ServiceB-testdata_1, docker_ServiceA-migrations_1
-	ServiceA_1 | INSERT 0 1
-	SerivceB_1 | {"level":"info","msg":"Starting up server","service":"ServiceA","time":"2022-02-10T00:41:53Z"}
+	{"level":"info","msg":"Starting up server","service":"ServiceA","time":"2022-02-10T00:41:53Z"}
 	END
     cat raw
 
     etestmsg "Expected formatted output"
 	cat <<-END >expect
-	"Attaching to docker_ServiceA_1, docker_ServiceB_1, docker_ServiceB-testdata_1, docker_ServiceA-migrations_1"
-	"INSERT 0 1"
 	{
 	  "level": "info",
 	  "msg": "Starting up server",
@@ -1725,18 +1717,29 @@ ETEST_docker_compose_run_follow_json()
 	END
     cat expect
 
-    emock "docker-compose" '
-    {
-        if [[ ${called} -eq 1 ]]; then
-            cat raw
-        fi
-    }'
-
-    etestmsg "Calling docker_compose_run with --follow-json"
-    docker_compose_run --no-wait --follow-json > actual
+    etestmsg "Calling docker_compose_run with --follow-json ServiceA"
+    docker_compose_run --no-wait --follow-json ServiceA > actual
 
     etestmsg "Verifying docker-compose called expected number of times"
     assert_emock_called "docker-compose" 2
+
+    etestmsg "Validating args (0)"
+    assert_emock_called_with "docker-compose" 0 \
+        --verbose                               \
+        --file docker-compose.yml               \
+        run
+
+    etestmsg "Validating args (1)"
+    assert_emock_called_with "docker-compose" 1 \
+        --file docker-compose.yml               \
+        ps -q ServiceA
+
+    etestmsg "Verifying docker called expected number of times"
+    assert_emock_called "docker" 1
+
+    etestmsg "Validating args (1)"
+    assert_emock_called_with "docker" 0 \
+        logs 42 --follow
 
     etestmsg "Actual Output"
     cat actual

--- a/tests/docker.etest
+++ b/tests/docker.etest
@@ -1312,7 +1312,7 @@ ETEST_docker_compose_run_wait_no_healthcheck()
         if [[ ${called} -eq 1 ]]; then
             echo "minio"
         else
-            echo ""
+            echo "42"
         fi
     }'
 
@@ -1327,7 +1327,7 @@ ETEST_docker_compose_run_wait_no_healthcheck()
     docker_compose_run --wait
 
     etestmsg "Verifying docker-compose called expected number of times"
-    assert_emock_called "docker-compose" 5
+    assert_emock_called "docker-compose" 4
 
     etestmsg "Validating arguments (0)"
     assert_emock_called_with "docker-compose" 0 \
@@ -1347,11 +1347,6 @@ ETEST_docker_compose_run_wait_no_healthcheck()
     etestmsg "Validating args (3)"
     assert_emock_called_with "docker-compose" 3 \
         --file docker-compose.yml               \
-        ps -q minio
-
-    etestmsg "Validating args (4)"
-    assert_emock_called_with "docker-compose" 4 \
-        --file docker-compose.yml               \
         logs --follow
 
     etestmsg "Verifying docker called expected number of times"
@@ -1359,11 +1354,11 @@ ETEST_docker_compose_run_wait_no_healthcheck()
 
     etestmsg "Validating arguments (0)"
     assert_emock_called_with "docker" 0 \
-        inspect
+        inspect 42
 
     etestmsg "Validating args (1)"
     assert_emock_called_with "docker" 1 \
-        inspect
+        inspect 42
 }
 
 ETEST_docker_compose_run_wait_with_healthcheck()
@@ -1373,7 +1368,7 @@ ETEST_docker_compose_run_wait_with_healthcheck()
         if [[ ${called} -eq 1 ]]; then
             echo "minio"
         else
-            echo ""
+            echo "42"
         fi
     }'
 
@@ -1417,7 +1412,7 @@ ETEST_docker_compose_run_wait_with_healthcheck()
 
     etestmsg "Validating arguments (0)"
     assert_emock_called_with "docker" 0 \
-        inspect
+        inspect 42
 }
 
 ETEST_docker_compose_run_default_wait_teardown()

--- a/tests/docker.etest
+++ b/tests/docker.etest
@@ -1225,6 +1225,7 @@ ETEST_docker_compose_run_envlist()
     etestmsg "Validating arguments (0)"
     assert_emock_called_with "docker-compose" 0 \
         --file docker-compose.yml               \
+        --verbose                               \
         --env-file "tmp/file1"                  \
         run
 
@@ -1248,6 +1249,7 @@ ETEST_docker_compose_run_file()
     etestmsg "Validating arguments (0)"
     assert_emock_called_with "docker-compose" 0 \
         --file foo.yml                          \
+        --verbose                               \
         run
 
     etestmsg "Validating args (1)"
@@ -1270,6 +1272,7 @@ ETEST_docker_compose_run_logfile()
     etestmsg "Validating arguments (0)"
     assert_emock_called_with "docker-compose" 0 \
         --file docker-compose.yml               \
+        --verbose                               \
         run
 
     etestmsg "Validating args (1)"
@@ -1292,6 +1295,7 @@ ETEST_docker_compose_run_wait()
     etestmsg "Validating arguments (0)"
     assert_emock_called_with "docker-compose" 0 \
         --file docker-compose.yml               \
+        --verbose                               \
         run
 
     etestmsg "Validating args (1)"
@@ -1332,6 +1336,7 @@ ETEST_docker_compose_run_wait_no_healthcheck()
     etestmsg "Validating arguments (0)"
     assert_emock_called_with "docker-compose" 0 \
         --file docker-compose.yml               \
+        --verbose                               \
         run
 
     etestmsg "Validating args (1)"
@@ -1390,6 +1395,7 @@ ETEST_docker_compose_run_wait_with_healthcheck()
     etestmsg "Validating arguments (0)"
     assert_emock_called_with "docker-compose" 0 \
         --file docker-compose.yml               \
+        --verbose                               \
         run
 
     etestmsg "Validating args (1)"
@@ -1432,6 +1438,7 @@ ETEST_docker_compose_run_default_wait_teardown()
     etestmsg "Validating arguments (0)"
     assert_emock_called_with "docker-compose" 0 \
         --file docker-compose.yml               \
+        --verbose                               \
         run
 
     etestmsg "Validating args (1)"
@@ -1447,6 +1454,7 @@ ETEST_docker_compose_run_default_wait_teardown()
     etestmsg "Validating teardown args"
     assert_emock_called_with "docker-compose" 3 \
         --file docker-compose.yml               \
+        --verbose                               \
         down                                    \
         --volumes                               \
         --remove-orphans
@@ -1469,6 +1477,7 @@ ETEST_docker_compose_run_custom_wait_teardown()
     etestmsg "Validating arguments (0)"
     assert_emock_called_with "docker-compose" 0 \
         --file docker-compose.yml               \
+        --verbose                               \
         run
 
     etestmsg "Validating args (1)"
@@ -1484,6 +1493,7 @@ ETEST_docker_compose_run_custom_wait_teardown()
     etestmsg "Validating teardown args"
     assert_emock_called_with "docker-compose" 3 \
         --file docker-compose.yml               \
+        --verbose                               \
         down                                    \
         --volumes
 }
@@ -1567,6 +1577,7 @@ ETEST_docker_compose_run_copy_to_volume()
     etestmsg "Validating args (0) -- docker-compose"
     assert_emock_called_with "docker-compose" 0 \
         --file docker-compose.yml               \
+        --verbose                               \
         run
 }
 
@@ -1620,6 +1631,7 @@ ETEST_docker_compose_run_copy_from_volume()
     etestmsg "Validating arguments (0)"
     assert_emock_called_with "docker-compose" 0 \
         --file docker-compose.yml               \
+        --verbose                               \
         run
 
     etestmsg "Validating args (1)"
@@ -1635,6 +1647,7 @@ ETEST_docker_compose_run_copy_from_volume()
     etestmsg "Validating teardown args"
     assert_emock_called_with "docker-compose" 3 \
         --file docker-compose.yml               \
+        --verbose                               \
         down                                    \
         --volumes                               \
         --remove-orphans
@@ -1656,32 +1669,10 @@ ETEST_docker_compose_run_passthrough_args()
     etestmsg "Verifying args"
     assert_emock_called_with "docker-compose" 0 \
         --file docker-compose.yml \
+        --verbose                 \
         run                       \
         --foo                     \
         --bar
-}
-
-ETEST_docker_compose_run_verbose_value()
-{
-    emock "docker-compose"
-
-    etestmsg "Calling docker_compose_run with --verbose=1"
-
-    docker_compose_run --no-wait --verbose=5
-
-    etestmsg "Verifying docker-compose called expected number of times"
-    assert_emock_called "docker-compose" 2
-
-    etestmsg "Verifying args"
-    assert_emock_called_with "docker-compose" 0 \
-        --file docker-compose.yml \
-        --verbose                 \
-        run
-
-    etestmsg "Validating args (2)"
-    assert_emock_called_with "docker-compose" 1 \
-        --file docker-compose.yml               \
-        logs --follow
 }
 
 ETEST_docker_compose_run_follow()


### PR DESCRIPTION
This adds a new convenience wrapper around `docker_compose` to make our lives a lot easier. From the docs, here is what it does:

`docker_compose_run` is an intelligent wrapper around vanilla `docker-compose` which integrates nicely with ebash. In
addition to the normal additional error checking and hardening the ebash variety brings, this version provides the
following super useful features:
- Accept a list of environment variables which should be exported into the underlying docker_compose run command. Each
  of these variables will be expanded in-place by ebash using `expand_vars`. As such the variables can be a simple list
  of env variables to export as in `FOO BAR ZAP` or they can point to other variables as in `FOO=PWD BAR ZAP` or they
  can point to string literals as in `FOO=/home/marshall BAR=1 ZAP=blah`. Each of these will be expanded into a
  formatted option and stored in an environment file that docker_compose will use.
- Create ephemeral docker volumes and copy a specified local path into the docker volume and attach that volume to the
  running docker containers. This is useful for running with a DOCKER_HOST which points to an external docker server.
- Automatically copy files into or out of the ephemeral docker volumes.
- Wait for the docker composed containers to be in a ready state.
- Tail the logs from the docker composed containers.