### PR TITLE
Add new --follow-all flag to docker_compose_run.

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -44,7 +44,6 @@ jobs:
           - "alpine-3.15"
           - "alpine-3.14"
           - "archlinux"
-          - "centos-8"
           - "centos-7"
           - "debian-11"
           - "debian-10"

--- a/Makefile
+++ b/Makefile
@@ -86,19 +86,18 @@ doc:
 #----------------------------------------------------------------------------------------------------------------------
 
 DISTROS =           \
-	alpine-3.15     \
 	alpine-3.14     \
+	alpine-3.15     \
 	archlinux       \
-	centos-8        \
 	centos-7        \
-	debian-11       \
 	debian-10       \
-	fedora-35       \
+	debian-11       \
 	fedora-33       \
+	fedora-35       \
 	gentoo          \
 	rocky-8         \
-	ubuntu-20.04    \
 	ubuntu-18.04    \
+	ubuntu-20.04    \
 
 # Template for running tests inside a Linux distro container
 DRUN = bin/ebash docker_run                                 \

--- a/doc/compatibility.md
+++ b/doc/compatibility.md
@@ -13,7 +13,6 @@ combinations:
 | Linux | Alpine | 3.15    |
 | Linux | Alpine | 3.14    |
 | Linux | Arch   | rolling |
-| Linux | CentOS | 8       |
 | Linux | CentOS | 7       |
 | Linux | Debian | 11      |
 | Linux | Debian | 10      |

--- a/install/go
+++ b/install/go
@@ -36,7 +36,7 @@ fi
 
 # If a package is available on this OS/distro install it. Otherwise download the package from upstream pre-built binary
 if [[ -n "${package}" ]]; then
-    pkg_install "${package}"
+    pkg_install --sync "${package}"
 elif os linux; then
 
     einfo "Go not available via package manager on $(os_pretty_name). Downloading from official Go URL."

--- a/share/docker.sh
+++ b/share/docker.sh
@@ -1006,10 +1006,10 @@ docker_compose_run()
     # asynchronously above.
     if [[ "${log_pid}" -ne 0 ]]; then
         if [[ ${follow_json} -eq 1 ]]; then
-            tail --pid "${log_pid}" --follow "${follow_logfile}" --sleep-interval=0.1 \
+            tail --pid "${log_pid}" --follow "${follow_logfile}" --retry 2>/dev/null \
                 | jq --unbuffered --raw-input '. as $line | try (fromjson) catch $line' || true
         else
-            tail --pid "${log_pid}" --follow "${follow_logfile}" || true
+            tail --pid "${log_pid}" --follow "${follow_logfile}" --retry 2>/dev/null || true
         fi
 
         wait "${pid}"

--- a/tests/docker.etest
+++ b/tests/docker.etest
@@ -1632,6 +1632,57 @@ ETEST_docker_compose_run_follow()
     diff -u expect actual
 }
 
+ETEST_docker_compose_run_follow_all()
+{
+    emock "docker"
+    emock "docker-compose" '
+    {
+        if [[ ${called} -eq 1 ]]; then
+            cat raw
+        fi
+    }'
+
+    etestmsg "Raw output"
+	cat <<-END >raw
+	ServiceA                   | {"level":"info","msg":"Starting up server","service":"ServiceA","time":"2022-02-10T00:41:53Z"}
+	ServiceB                   | {"level":"info","msg":"Starting up server","service":"ServiceB","time":"2022-02-10T00:41:53Z"}
+	ServiceWithAReallyLongName | {"level":"info","msg":"Starting up server","service":"ServiceC","time":"2022-02-10T00:41:53Z"}
+	END
+    cat raw
+
+    etestmsg "Expected output"
+	cat <<-END >expect
+	{"level":"info","msg":"Starting up server","service":"ServiceA","time":"2022-02-10T00:41:53Z"}
+	{"level":"info","msg":"Starting up server","service":"ServiceB","time":"2022-02-10T00:41:53Z"}
+	{"level":"info","msg":"Starting up server","service":"ServiceC","time":"2022-02-10T00:41:53Z"}
+	END
+    cat expect
+
+    etestmsg "Calling docker_compose_run with --follow-all"
+    docker_compose_run --no-wait --follow-all > actual
+
+    assert_emock_called "docker-compose" 2
+
+    assert_emock_called_with "docker-compose" 0 \
+        --verbose                               \
+        --file docker-compose.yml               \
+        run -T
+
+    assert_emock_called_with "docker-compose" 1 \
+        --file docker-compose.yml               \
+        logs                                    \
+        --follow                                \
+        --no-color                              \
+
+    assert_emock_called "docker" 0
+
+    etestmsg "Actual Output"
+    cat actual
+
+    etestmsg "Diff"
+    diff -u expect actual
+}
+
 ETEST_docker_compose_run_follow_logfile()
 {
     emock "docker-compose" '
@@ -1720,8 +1771,8 @@ ETEST_docker_compose_run_follow_json()
 	END
     cat expect
 
-    etestmsg "Calling docker_compose_run with --follow-json ServiceA"
-    docker_compose_run --no-wait --follow-json ServiceA > actual
+    etestmsg "Calling docker_compose_run with --follow ServiceA --follow-json"
+    docker_compose_run --no-wait --follow ServiceA --follow-json > actual
 
     assert_emock_called "docker-compose" 2
 


### PR DESCRIPTION
This is an enhancement to the new `docker_compose_run` in ebash so that in manticore repo we can tail the output of all the docker containers rather than just `sftp` when we do a `make run`