### PR TITLE
Ensure volums and anonymous volumes associated with container are deleted

### DIFF
--- a/share/docker.sh
+++ b/share/docker.sh
@@ -709,7 +709,7 @@ __docker_setup_copy_volumes()
         docker rm "/${name}" &>/dev/null || true
         docker container create --name "${name}" -v "${name}:${rpath}" busybox | edebug
         trap_add "docker volume rm ${name} |& edebug"
-        trap_add "docker rm ${name} |& edebug"
+        trap_add "docker rm --volumes ${name} |& edebug"
         docker cp "${lpath}/." "${name}:${rpath}"
 
         if [[ "${add_volume_to_args}" -eq 1 ]]; then

--- a/tests/docker.etest
+++ b/tests/docker.etest
@@ -1101,19 +1101,19 @@ ETEST_docker_run_copy_to_volume()
         --volume=ebash:/baggins \
 
     assert_emock_called_with "docker" 10 \
-        rm ebash
+        rm --volumes ebash
 
     assert_emock_called_with "docker" 11 \
         volume rm ebash
 
     assert_emock_called_with "docker" 12 \
-        rm data
+        rm --volumes data
 
     assert_emock_called_with "docker" 13 \
         volume rm data
 
     assert_emock_called_with "docker" 14 \
-        rm foo
+        rm --volumes foo
 
     assert_emock_called_with "docker" 15 \
         volume rm foo
@@ -1472,19 +1472,19 @@ ETEST_docker_compose_run_copy_to_volume()
         cp "/home/ebash/." "ebash:/baggins"
 
     assert_emock_called_with "docker" 9 \
-        rm ebash
+        rm --volumes ebash
 
     assert_emock_called_with "docker" 10 \
         volume rm ebash
 
     assert_emock_called_with "docker" 11 \
-        rm data
+        rm --volumes data
 
     assert_emock_called_with "docker" 12 \
         volume rm data
 
     assert_emock_called_with "docker" 13 \
-        rm foo
+        rm --volumes foo
 
     assert_emock_called_with "docker" 14 \
         volume rm foo


### PR DESCRIPTION
Add some additional hardening around teardown after `docker run` and `docker-compose run` operations where ephemeral volumes are created. Ensures when we delete the ephemeral container any of its attached volumes are also deleted.