### PR TITLE
Docker ports

### DIFF
--- a/share/docker.sh
+++ b/share/docker.sh
@@ -699,7 +699,7 @@ __docker_setup_copy_volumes()
         return 0
     fi
 
-    einfo "Creating docker $(lval copy_to_volumes)"
+    einfo "Creating docker $(lval copy_to_volume)"
 
     # Deal with all copy_to_volumes
     local entry name parts
@@ -1049,7 +1049,6 @@ docker_compose_run()
             readarray -t services < <(docker-compose --file "${file}" ps --services)
         fi
 
-        echo >&2
         einfo "Waiting for $(lval services)"
         for service in ${services[*]:-}; do
 

--- a/share/docker.sh
+++ b/share/docker.sh
@@ -786,7 +786,7 @@ __docker_setup_ssh_port_forwarding()
 
         edebug "Creating SSH Port Forward $(lval docker_user docker_host docker_port lport rport)"
 
-        ssh -NL "127.0.0.1:${lport}:127.0.0.1:${rport}" "${docker_user}@${docker_host} -p ${docker_port}" &
+        ssh -NL "127.0.0.1:${lport}:127.0.0.1:${rport}" "${docker_user}@${docker_host}" -p ${docker_port} &
         trap_add "ekill $!"
     done
 }

--- a/share/docker.sh
+++ b/share/docker.sh
@@ -695,11 +695,9 @@ __docker_setup_copy_volumes()
         "+add_volume_to_args | Whether to add --volume flags to docker_args" \
     )
 
-    if array_empty copy_to_volume; then
-        return 0
+    if array_not_empty copy_to_volume; then
+        einfo "Creating docker $(lval copy_to_volume)"
     fi
-
-    einfo "Creating docker $(lval copy_to_volume)"
 
     # Deal with all copy_to_volumes
     local entry name parts

--- a/share/docker.sh
+++ b/share/docker.sh
@@ -737,6 +737,60 @@ __docker_setup_copy_volumes()
     done
 }
 
+opt_usage __docker_setup_ssh_port_forwarding<<'END'
+__docker_setup_ssh_port_forwarding is an internal only helper function used to setup SSH Port Forwarding when docker is
+used with a remote SSH DOCKER_HOST. This will essentially create some local SSH port forwarding so that the ports that
+are being exposed on the remote docker host can be accessed locally. The syntax for this option is as follows:
+
+- local_port:remote_port
+- local_port
+
+When the shorter syntax of `local_port` is used, then the same port will be used both locally and remote. e.g. `8080` is
+equivalent to `8080:8080`.
+
+END
+__docker_setup_ssh_port_forwarding()
+{
+    local docker_user docker_host docker_port
+    edebug "__docker_setup_ssh_port_forwarding called with $(lval DOCKER_HOST)"
+
+    if [[ -z "${DOCKER_HOST}" ]]; then
+        return 0
+    elif [[ "${DOCKER_HOST}" =~ ssh://([^@]+)@([^:]+):([0-9]+)$ ]]; then
+        docker_user="${BASH_REMATCH[1]}"
+        docker_host="${BASH_REMATCH[2]}"
+        docker_port="${BASH_REMATCH[3]}"
+    elif [[ "${DOCKER_HOST}" =~ ssh://([^@]+)@([^:]+)$ ]]; then
+        docker_user="${BASH_REMATCH[1]}"
+        docker_host="${BASH_REMATCH[2]}"
+        docker_port="22"
+    else
+        die "Unsupported $(lval DOCKER_HOST)"
+    fi
+
+    local entry name parts
+    for entry in ${ssh_port_forward[*]:-}; do
+
+        array_init parts "${entry}" ":"
+
+        local lport rport
+        if [[ $(array_size parts) -eq 2 ]]; then
+            lport=${parts[0]}
+            rport=${parts[1]}
+        elif [[ $(array_size parts) -eq 1 ]]; then
+            lport=${parts[0]}
+            rport=${parts[0]}
+        else
+            die "Illegal syntax for ssh_port_forward: ${entry}"
+        fi
+
+        edebug "Creating SSH Port Forward $(lval docker_user docker_host docker_port lport rport)"
+
+        ssh -NL "127.0.0.1:${lport}:127.0.0.1:${rport}" "${docker_user}@${docker_host}:${docker_port}" &
+        trap_add "ekill $!"
+    done
+}
+
 opt_usage __docker_wait_for_container_id <<'END'
 __docker_wait_for_container_id is an internal only helper function used to wait for a named container to have an
 assigned container ID.
@@ -773,6 +827,8 @@ useful features:
 - Create ephemeral docker volumes and copy a specified local path into the docker volume and attach that volume to the
   running docker container. This is useful for running with a DOCKER_HOST which points to an external docker server.
 - Automatically determine what value to use for --interactive.
+- Optionally setup SSH Port Forwarding when used with a remote DOCKER_HOST. If DOCKER_HOST is not set to a remote SSH
+  host, then this option will have no effect.
 END
 docker_run()
 {
@@ -793,6 +849,8 @@ docker_run()
                                               list. This is because docker cp doesn't support an exclusion mechanism." \
         ":interactive=auto                  | This can be 'yes' or 'no' or 'auto' to automatically determine if we are
                                               interactive by looking at we're run from an interactive shell or not."   \
+        "&ssh_port_forward                  | Setup SSH Port Forwarding for use with remote DOCKER_HOST. If DOCKER_HOST
+                                              is not set to a remote SSH host, then this option has no effect."        \
     )
 
     # Final list of docker args we will use
@@ -818,6 +876,9 @@ docker_run()
 
     # Setup copy_to_volumes and copy_from_volume and copy_from_volume_delete
     __docker_setup_copy_volumes --add-volume-to-args
+
+    # Setup SSH Port Forwarding
+    __docker_setup_ssh_port_forwarding
 
     # Set --interactive as requested
     if [[ "${interactive,,}" == "yes" ]]; then
@@ -856,6 +917,8 @@ following super useful features:
 - Wait for the docker composed containers to be in a ready state.
 - Tail the logs from the docker composed containers.
 - Automatically teardown the docker composed containers safely and also remove the volumes.
+- Optionally setup SSH Port Forwarding when used with a remote DOCKER_HOST. If DOCKER_HOST is not set to a remote SSH
+  host, then this option will have no effect.
 END
 docker_compose_run()
 {
@@ -882,6 +945,8 @@ docker_compose_run()
         ":follow_logfile                    | Optional file to capture the output from followed containers into in
                                               addition to following on the console."                                   \
         ":logfile                           | Optional logfile to capture all docker-compose output into."             \
+        "&ssh_port_forward                  | Setup SSH Port Forwarding for use with remote DOCKER_HOST. If DOCKER_HOST
+                                              is not set to a remote SSH host, then this option has no effect."        \
         ":teardown                          | Teardown code to execute after docker_compose completion to perform any
                                               necessary cleanup. This is a useful mechanism to ensure we bring down all
                                               containers and volumes via teardown='down --volumes --remove-orphans'"   \
@@ -917,9 +982,17 @@ docker_compose_run()
     # Setup copy_to_volumes and copy_from_volume and copy_from_volume_delete
     __docker_setup_copy_volumes --no-add-volume-to-args
 
+    # Setup SSH Port Forwarding
+    __docker_setup_ssh_port_forwarding
+
     # Setup any additional teardown traps
     : ${teardown:="down --volumes --remove-orphans"}
     trap_add "echo >&2 ; einfo Teardown ; docker-compose ${docker_args[*]} ${teardown}"
+
+    # Setup trap to capture logs
+    if [[ -n "${logfile}" ]]; then
+        trap_add "docker-compose --file \"${file}\" logs > \"${logfile}\""
+    fi
 
     # Launch docker-compose in teh background and tail the logs in the foreground writing to the requested logfile.
     # The tailing of the logfile will run in the foreground and block until the parent docker-compose job completes.
@@ -1018,10 +1091,4 @@ docker_compose_run()
     # Wait on our backgrounded process and propogate any failure from it.
     edebug "Waiting for docker-compose to complete"
     wait "${pid}"
-
-    # Optionally capture all container logfiles
-    if [[ -n "${logfile}" ]]; then
-        edebug "Capturing docker-compose logfile"
-        docker-compose --file "${file}" logs > "${logfile}"
-    fi
 }

--- a/share/docker.sh
+++ b/share/docker.sh
@@ -754,13 +754,13 @@ __docker_setup_ssh_port_forwarding()
     local docker_user docker_host docker_port
     edebug "__docker_setup_ssh_port_forwarding called with $(lval DOCKER_HOST)"
 
-    if [[ -z "${DOCKER_HOST}" ]]; then
+    if [[ -z "${DOCKER_HOST:-}" ]]; then
         return 0
-    elif [[ "${DOCKER_HOST}" =~ ssh://([^@]+)@([^:]+):([0-9]+)$ ]]; then
+    elif [[ "${DOCKER_HOST:-}" =~ ssh://([^@]+)@([^:]+):([0-9]+)$ ]]; then
         docker_user="${BASH_REMATCH[1]}"
         docker_host="${BASH_REMATCH[2]}"
         docker_port="${BASH_REMATCH[3]}"
-    elif [[ "${DOCKER_HOST}" =~ ssh://([^@]+)@([^:]+)$ ]]; then
+    elif [[ "${DOCKER_HOST:-}" =~ ssh://([^@]+)@([^:]+)$ ]]; then
         docker_user="${BASH_REMATCH[1]}"
         docker_host="${BASH_REMATCH[2]}"
         docker_port="22"

--- a/share/docker.sh
+++ b/share/docker.sh
@@ -695,6 +695,12 @@ __docker_setup_copy_volumes()
         "+add_volume_to_args | Whether to add --volume flags to docker_args" \
     )
 
+    if array_empty copy_to_volume; then
+        return 0
+    fi
+
+    einfo "Creating docker $(lval copy_to_volumes)"
+
     # Deal with all copy_to_volumes
     local entry name parts
     for entry in ${copy_to_volume[*]:-}; do
@@ -705,7 +711,7 @@ __docker_setup_copy_volumes()
         local lpath=${parts[1]}
         local rpath=${parts[2]}
 
-        einfo "Creating docker container for volume $(lval name lpath rpath)"
+        edebug "Creating docker container for volume $(lval name lpath rpath)"
         docker rm "/${name}" &>/dev/null || true
         docker container create --name "${name}" -v "${name}:${rpath}" busybox | edebug
         trap_add "docker volume rm ${name} |& edebug"
@@ -757,6 +763,8 @@ __docker_setup_ssh_port_forwarding()
         return 0
     fi
 
+    einfo "Creating docker $(lval ssh_port_forward)"
+
     # Get the docker context we are running under.
     #
     # NOTES:
@@ -795,7 +803,7 @@ __docker_setup_ssh_port_forwarding()
             die "Illegal syntax for ssh_port_forward: ${entry}"
         fi
 
-        einfo "Creating SSH Port Forward $(lval docker_user docker_host docker_port lport rport)"
+        edebug "Creating SSH Port Forward $(lval docker_user docker_host docker_port lport rport)"
 
         ssh -NL "127.0.0.1:${lport}:127.0.0.1:${rport}" "${docker_user}@${docker_host}" -p ${docker_port} &
         trap_add "ekill $!"

--- a/share/docker.sh
+++ b/share/docker.sh
@@ -786,7 +786,7 @@ __docker_setup_ssh_port_forwarding()
 
         edebug "Creating SSH Port Forward $(lval docker_user docker_host docker_port lport rport)"
 
-        ssh -NL "127.0.0.1:${lport}:127.0.0.1:${rport}" "${docker_user}@${docker_host}:${docker_port}" &
+        ssh -NL "127.0.0.1:${lport}:127.0.0.1:${rport}" "${docker_user}@${docker_host} -p ${docker_port}" &
         trap_add "ekill $!"
     done
 }

--- a/share/docker.sh
+++ b/share/docker.sh
@@ -705,7 +705,7 @@ __docker_setup_copy_volumes()
         local lpath=${parts[1]}
         local rpath=${parts[2]}
 
-        edebug "Creating docker container for volume $(lval name lpath rpath)"
+        einfo "Creating docker container for volume $(lval name lpath rpath)"
         docker rm "/${name}" &>/dev/null || true
         docker container create --name "${name}" -v "${name}:${rpath}" busybox | edebug
         trap_add "docker volume rm ${name} |& edebug"
@@ -767,11 +767,11 @@ __docker_setup_ssh_port_forwarding()
     local docker_context docker_user docker_host docker_port
     docker_host=$(docker context inspect | jq --raw-output '.[0].Endpoints.docker.Host')
     edebug "Docker context $(lval docker_host)"
-    if [[ "${DOCKER_HOST:-}" =~ ssh://([^@]+)@([^:]+):([0-9]+)$ ]]; then
+    if [[ "${docker_host}" =~ ssh://([^@]+)@([^:]+):([0-9]+)$ ]]; then
         docker_user="${BASH_REMATCH[1]}"
         docker_host="${BASH_REMATCH[2]}"
         docker_port="${BASH_REMATCH[3]}"
-    elif [[ "${DOCKER_HOST:-}" =~ ssh://([^@]+)@([^:]+)$ ]]; then
+    elif [[ "${docker_host}" =~ ssh://([^@]+)@([^:]+)$ ]]; then
         docker_user="${BASH_REMATCH[1]}"
         docker_host="${BASH_REMATCH[2]}"
         docker_port="22"
@@ -795,7 +795,7 @@ __docker_setup_ssh_port_forwarding()
             die "Illegal syntax for ssh_port_forward: ${entry}"
         fi
 
-        edebug "Creating SSH Port Forward $(lval docker_user docker_host docker_port lport rport)"
+        einfo "Creating SSH Port Forward $(lval docker_user docker_host docker_port lport rport)"
 
         ssh -NL "127.0.0.1:${lport}:127.0.0.1:${rport}" "${docker_user}@${docker_host}" -p ${docker_port} &
         trap_add "ekill $!"

--- a/tests/docker.etest
+++ b/tests/docker.etest
@@ -1206,7 +1206,7 @@ ETEST_docker_run_ssh_port_forward()
     assert_emock_called_with "ssh" 0  \
         -NL                           \
         127.0.0.1:8080:127.0.0.1:8080 \
-        someuser@somehost:1234
+        someuser@somehost -p 1234
 }
 
 ETEST_docker_run_ssh_port_forward_multiple()
@@ -1227,12 +1227,12 @@ ETEST_docker_run_ssh_port_forward_multiple()
     assert_emock_called_with "ssh" 0  \
         -NL                           \
         127.0.0.1:8080:127.0.0.1:8080 \
-        someuser@somehost:22
+        someuser@somehost -p 22
 
     assert_emock_called_with "ssh" 1  \
         -NL                           \
         127.0.0.1:2222:127.0.0.1:2222 \
-        someuser@somehost:22
+        someuser@somehost -p 22
 }
 
 ETEST_docker_run_ssh_port_forward_diff()
@@ -1253,7 +1253,7 @@ ETEST_docker_run_ssh_port_forward_diff()
     assert_emock_called_with "ssh" 0 \
         -NL                          \
         127.0.0.1:80:127.0.0.1:8080  \
-        someuser@somehost:1234
+        someuser@somehost -p 1234
 }
 
 ETEST_docker_run_ssh_port_forward_diff_multiple()
@@ -1274,12 +1274,12 @@ ETEST_docker_run_ssh_port_forward_diff_multiple()
     assert_emock_called_with "ssh" 0 \
         -NL                          \
         127.0.0.1:80:127.0.0.1:8080  \
-        someuser@somehost:22
+        someuser@somehost -p 22
 
     assert_emock_called_with "ssh" 1 \
         -NL                          \
         127.0.0.1:22:127.0.0.1:2222  \
-        someuser@somehost:22
+        someuser@somehost -p 22
 }
 
 ETEST_docker_compose_run_envlist()
@@ -1907,7 +1907,7 @@ ETEST_docker_compose_run_ssh_port_forward()
     assert_emock_called_with "ssh" 0  \
         -NL                           \
         127.0.0.1:8080:127.0.0.1:8080 \
-        someuser@somehost:1234
+        someuser@somehost -p 1234
 }
 
 ETEST_docker_compose_run_ssh_port_forward_multiple()
@@ -1930,12 +1930,12 @@ ETEST_docker_compose_run_ssh_port_forward_multiple()
     assert_emock_called_with "ssh" 0  \
         -NL                           \
         127.0.0.1:8080:127.0.0.1:8080 \
-        someuser@somehost:22
+        someuser@somehost -p 22
 
     assert_emock_called_with "ssh" 1  \
         -NL                           \
         127.0.0.1:2222:127.0.0.1:2222 \
-        someuser@somehost:22
+        someuser@somehost -p 22
 }
 
 ETEST_docker_compose_run_ssh_port_forward_diff()

--- a/tests/docker.etest
+++ b/tests/docker.etest
@@ -1227,7 +1227,7 @@ ETEST_docker_run_ssh_port_forward()
     mock_docker_with_context
     emock "ssh"
 
-    docker_run --ssh-port-forward 8080
+    docker_run --interactive=no --ssh-port-forward 8080
 
     assert_emock_called "docker" 2
 
@@ -1236,8 +1236,7 @@ ETEST_docker_run_ssh_port_forward()
         inspect
 
     assert_emock_called_with "docker" 1 \
-        run           \
-        --interactive
+        run
 
     assert_emock_called "ssh" 1
     assert_emock_called_with "ssh" 0  \
@@ -1251,7 +1250,7 @@ ETEST_docker_run_ssh_port_forward_context()
     mock_docker_with_context
     emock "ssh"
 
-    docker_run --ssh-port-forward 8080
+    docker_run --interactive=no --ssh-port-forward 8080
 
     assert_emock_called "docker" 2
 
@@ -1260,8 +1259,7 @@ ETEST_docker_run_ssh_port_forward_context()
         inspect
 
     assert_emock_called_with "docker" 1 \
-        run           \
-        --interactive
+        run
 
     assert_emock_called "ssh" 1
     assert_emock_called_with "ssh" 0  \
@@ -1275,7 +1273,7 @@ ETEST_docker_run_ssh_port_forward_multiple()
     mock_docker_with_context
     emock "ssh"
 
-    docker_run --ssh-port-forward 8080 --ssh-port-forward 2222
+    docker_run --interactive=no --ssh-port-forward 8080 --ssh-port-forward 2222
 
     assert_emock_called "docker" 2
 
@@ -1284,8 +1282,7 @@ ETEST_docker_run_ssh_port_forward_multiple()
         inspect
 
     assert_emock_called_with "docker" 1 \
-        run           \
-        --interactive
+        run
 
     assert_emock_called "ssh" 2
     assert_emock_called_with "ssh" 0  \
@@ -1304,7 +1301,7 @@ ETEST_docker_run_ssh_port_forward_diff()
     mock_docker_with_context
     emock "ssh"
 
-    docker_run --ssh-port-forward 80:8080
+    docker_run --interactive=no --ssh-port-forward 80:8080
 
     assert_emock_called "docker" 2
 
@@ -1313,8 +1310,7 @@ ETEST_docker_run_ssh_port_forward_diff()
         inspect
 
     assert_emock_called_with "docker" 1 \
-        run           \
-        --interactive
+        run
 
     assert_emock_called "ssh" 1
     assert_emock_called_with "ssh" 0 \
@@ -1328,7 +1324,7 @@ ETEST_docker_run_ssh_port_forward_diff_multiple()
     mock_docker_with_context
     emock "ssh"
 
-    docker_run --ssh-port-forward 80:8080 --ssh-port-forward 22:2222
+    docker_run --interactive=no --ssh-port-forward 80:8080 --ssh-port-forward 22:2222
 
     assert_emock_called "docker" 2
 
@@ -1337,8 +1333,7 @@ ETEST_docker_run_ssh_port_forward_diff_multiple()
         inspect
 
     assert_emock_called_with "docker" 1 \
-        run           \
-        --interactive
+        run
 
     assert_emock_called "ssh" 2
     assert_emock_called_with "ssh" 0 \

--- a/tests/docker.etest
+++ b/tests/docker.etest
@@ -1188,6 +1188,100 @@ ETEST_docker_run_passthrough_args()
         --workdir /ebash
 }
 
+ETEST_docker_run_ssh_port_forward()
+{
+    export DOCKER_HOST="ssh://someuser@somehost:1234"
+
+    emock "docker"
+    emock "ssh"
+
+    docker_run --ssh-port-forward 8080
+
+    assert_emock_called "docker" 1
+    assert_emock_called_with "docker" 0 \
+        run           \
+        --interactive
+
+    assert_emock_called "ssh" 1
+    assert_emock_called_with "ssh" 0  \
+        -NL                           \
+        127.0.0.1:8080:127.0.0.1:8080 \
+        someuser@somehost:1234
+}
+
+ETEST_docker_run_ssh_port_forward_multiple()
+{
+    export DOCKER_HOST="ssh://someuser@somehost"
+
+    emock "docker"
+    emock "ssh"
+
+    docker_run --ssh-port-forward 8080 --ssh-port-forward 2222
+
+    assert_emock_called "docker" 1
+    assert_emock_called_with "docker" 0 \
+        run           \
+        --interactive
+
+    assert_emock_called "ssh" 2
+    assert_emock_called_with "ssh" 0  \
+        -NL                           \
+        127.0.0.1:8080:127.0.0.1:8080 \
+        someuser@somehost:22
+
+    assert_emock_called_with "ssh" 1  \
+        -NL                           \
+        127.0.0.1:2222:127.0.0.1:2222 \
+        someuser@somehost:22
+}
+
+ETEST_docker_run_ssh_port_forward_diff()
+{
+    export DOCKER_HOST="ssh://someuser@somehost:1234"
+
+    emock "docker"
+    emock "ssh"
+
+    docker_run --ssh-port-forward 80:8080
+
+    assert_emock_called "docker" 1
+    assert_emock_called_with "docker" 0 \
+        run           \
+        --interactive
+
+    assert_emock_called "ssh" 1
+    assert_emock_called_with "ssh" 0 \
+        -NL                          \
+        127.0.0.1:80:127.0.0.1:8080  \
+        someuser@somehost:1234
+}
+
+ETEST_docker_run_ssh_port_forward_diff_multiple()
+{
+    export DOCKER_HOST="ssh://someuser@somehost"
+
+    emock "docker"
+    emock "ssh"
+
+    docker_run --ssh-port-forward 80:8080 --ssh-port-forward 22:2222
+
+    assert_emock_called "docker" 1
+    assert_emock_called_with "docker" 0 \
+        run           \
+        --interactive
+
+    assert_emock_called "ssh" 2
+    assert_emock_called_with "ssh" 0 \
+        -NL                          \
+        127.0.0.1:80:127.0.0.1:8080  \
+        someuser@somehost:22
+
+    assert_emock_called_with "ssh" 1 \
+        -NL                          \
+        127.0.0.1:22:127.0.0.1:2222  \
+        someuser@somehost:22
+}
+
 ETEST_docker_compose_run_envlist()
 {
     emock --stdout "tmp/file1" "mktemp"
@@ -1236,16 +1330,12 @@ ETEST_docker_compose_run_logfile()
 
     docker_compose_run --no-wait --logfile foo.log
 
-    assert_emock_called "docker-compose" 2
+    assert_emock_called "docker-compose" 1
 
     assert_emock_called_with "docker-compose" 0 \
         --verbose                               \
         --file docker-compose.yml               \
         run -T
-
-    assert_emock_called_with "docker-compose" 1 \
-        --file docker-compose.yml               \
-        logs
 }
 
 ETEST_docker_compose_run_wait()
@@ -1795,4 +1885,106 @@ ETEST_docker_compose_run_follow_json()
 
     etestmsg "Diff"
     diff -u expect actual
+}
+
+ETEST_docker_compose_run_ssh_port_forward()
+{
+    export DOCKER_HOST="ssh://someuser@somehost:1234"
+
+    emock "docker-compose"
+    emock "docker"
+    emock "ssh"
+
+    docker_compose_run --no-wait --ssh-port-forward 8080
+
+    assert_emock_called "docker-compose" 1
+    assert_emock_called_with "docker-compose" 0 \
+        --verbose                 \
+        --file docker-compose.yml \
+        run -T
+
+    assert_emock_called "ssh" 1
+    assert_emock_called_with "ssh" 0  \
+        -NL                           \
+        127.0.0.1:8080:127.0.0.1:8080 \
+        someuser@somehost:1234
+}
+
+ETEST_docker_compose_run_ssh_port_forward_multiple()
+{
+    export DOCKER_HOST="ssh://someuser@somehost"
+
+    emock "docker-compose"
+    emock "docker"
+    emock "ssh"
+
+    docker_compose_run --no-wait --ssh-port-forward 8080 --ssh-port-forward 2222
+
+    assert_emock_called "docker-compose" 1
+    assert_emock_called_with "docker-compose" 0 \
+        --verbose                 \
+        --file docker-compose.yml \
+        run -T
+
+    assert_emock_called "ssh" 2
+    assert_emock_called_with "ssh" 0  \
+        -NL                           \
+        127.0.0.1:8080:127.0.0.1:8080 \
+        someuser@somehost:22
+
+    assert_emock_called_with "ssh" 1  \
+        -NL                           \
+        127.0.0.1:2222:127.0.0.1:2222 \
+        someuser@somehost:22
+}
+
+ETEST_docker_compose_run_ssh_port_forward_diff()
+{
+    export DOCKER_HOST="ssh://someuser@somehost:1234"
+
+    emock "docker-compose"
+    emock "docker"
+    emock "ssh"
+
+    docker_compose_run --no-wait --ssh-port-forward 80:8080
+
+    assert_emock_called "docker-compose" 1
+    assert_emock_called_with "docker-compose" 0 \
+        --verbose                 \
+        --file docker-compose.yml \
+        run -T
+
+    assert_emock_called "ssh" 1
+    assert_emock_called_with "ssh" 0 \
+        -NL                          \
+        127.0.0.1:80:127.0.0.1:8080  \
+        someuser@somehost:1234
+}
+
+ETEST_docker_compose_run_ssh_port_forward_diff_multiple()
+{
+    export DOCKER_HOST="ssh://someuser@somehost"
+
+    emock "docker-compose"
+    emock "docker"
+    emock "ssh"
+
+    docker_compose_run --no-wait --ssh-port-forward 80:8080 --ssh-port-forward 22:2222
+
+    assert_emock_called "docker-compose" 1
+    assert_emock_called_with "docker-compose" 0 \
+        --verbose                 \
+        --file docker-compose.yml \
+        run -T
+
+    assert_emock_called "ssh" 2
+    assert_emock_called_with "ssh" 0 \
+        -NL                          \
+        127.0.0.1:80:127.0.0.1:8080  \
+        someuser@somehost:22
+
+    assert_emock_called_with "ssh" 1 \
+        -NL                          \
+        127.0.0.1:22:127.0.0.1:2222  \
+        someuser@somehost:22
 }

--- a/tests/docker.etest
+++ b/tests/docker.etest
@@ -1197,8 +1197,66 @@ ETEST_docker_run_ssh_port_forward()
 
     docker_run --ssh-port-forward 8080
 
-    assert_emock_called "docker" 1
+    assert_emock_called "docker" 2
+
     assert_emock_called_with "docker" 0 \
+        context \
+        inspect
+
+    assert_emock_called_with "docker" 2 \
+        run           \
+        --interactive
+
+    assert_emock_called "ssh" 1
+    assert_emock_called_with "ssh" 0  \
+        -NL                           \
+        127.0.0.1:8080:127.0.0.1:8080 \
+        someuser@somehost -p 1234
+}
+
+ETEST_docker_run_ssh_port_forward_context()
+{
+    etestmsg "Fake docker context"
+	cat <<-END >context
+	[
+	  {
+	    "Name": "default",
+	    "Metadata": {
+	      "StackOrchestrator": "swarm"
+	    },
+	    "Endpoints": {
+	      "docker": {
+	        "Host": "ssh://marshall@asgard",
+	        "SkipTLSVerify": false
+	      }
+	    },
+	    "TLSMaterial": {},
+	    "Storage": {
+	      "MetadataPath": "<IN MEMORY>",
+	      "TLSPath": "<IN MEMORY>"
+	    }
+	  }
+	]
+	END
+    cat context
+
+    emock "ssh"
+    emock "docker" '
+    {
+        if [[ $1 == "context" && $2 == "inspect" ]]; then
+            cat context
+        fi
+    }'
+
+    docker_run --ssh-port-forward 8080
+
+    assert_emock_called "docker" 2
+
+    assert_emock_called_with "docker" 0 \
+        context \
+        inspect
+
+    assert_emock_called_with "docker" 1 \
         run           \
         --interactive
 
@@ -1218,8 +1276,13 @@ ETEST_docker_run_ssh_port_forward_multiple()
 
     docker_run --ssh-port-forward 8080 --ssh-port-forward 2222
 
-    assert_emock_called "docker" 1
+    assert_emock_called "docker" 2
+
     assert_emock_called_with "docker" 0 \
+        context \
+        inspect
+
+    assert_emock_called_with "docker" 2 \
         run           \
         --interactive
 
@@ -1244,8 +1307,13 @@ ETEST_docker_run_ssh_port_forward_diff()
 
     docker_run --ssh-port-forward 80:8080
 
-    assert_emock_called "docker" 1
+    assert_emock_called "docker" 2
+
     assert_emock_called_with "docker" 0 \
+        context \
+        inspect
+
+    assert_emock_called_with "docker" 1 \
         run           \
         --interactive
 
@@ -1265,8 +1333,13 @@ ETEST_docker_run_ssh_port_forward_diff_multiple()
 
     docker_run --ssh-port-forward 80:8080 --ssh-port-forward 22:2222
 
-    assert_emock_called "docker" 1
+    assert_emock_called "docker" 2
+
     assert_emock_called_with "docker" 0 \
+        context \
+        inspect
+
+    assert_emock_called_with "docker" 1 \
         run           \
         --interactive
 
@@ -1892,7 +1965,6 @@ ETEST_docker_compose_run_ssh_port_forward()
     export DOCKER_HOST="ssh://someuser@somehost:1234"
 
     emock "docker-compose"
-    emock "docker"
     emock "ssh"
 
     docker_compose_run --no-wait --ssh-port-forward 8080
@@ -1915,7 +1987,6 @@ ETEST_docker_compose_run_ssh_port_forward_multiple()
     export DOCKER_HOST="ssh://someuser@somehost"
 
     emock "docker-compose"
-    emock "docker"
     emock "ssh"
 
     docker_compose_run --no-wait --ssh-port-forward 8080 --ssh-port-forward 2222
@@ -1943,7 +2014,6 @@ ETEST_docker_compose_run_ssh_port_forward_diff()
     export DOCKER_HOST="ssh://someuser@somehost:1234"
 
     emock "docker-compose"
-    emock "docker"
     emock "ssh"
 
     docker_compose_run --no-wait --ssh-port-forward 80:8080
@@ -1958,7 +2028,7 @@ ETEST_docker_compose_run_ssh_port_forward_diff()
     assert_emock_called_with "ssh" 0 \
         -NL                          \
         127.0.0.1:80:127.0.0.1:8080  \
-        someuser@somehost:1234
+        someuser@somehost -p 1234
 }
 
 ETEST_docker_compose_run_ssh_port_forward_diff_multiple()
@@ -1966,7 +2036,6 @@ ETEST_docker_compose_run_ssh_port_forward_diff_multiple()
     export DOCKER_HOST="ssh://someuser@somehost"
 
     emock "docker-compose"
-    emock "docker"
     emock "ssh"
 
     docker_compose_run --no-wait --ssh-port-forward 80:8080 --ssh-port-forward 22:2222
@@ -1981,10 +2050,10 @@ ETEST_docker_compose_run_ssh_port_forward_diff_multiple()
     assert_emock_called_with "ssh" 0 \
         -NL                          \
         127.0.0.1:80:127.0.0.1:8080  \
-        someuser@somehost:22
+        someuser@somehost -p 22
 
     assert_emock_called_with "ssh" 1 \
         -NL                          \
         127.0.0.1:22:127.0.0.1:2222  \
-        someuser@somehost:22
+        someuser@somehost -p 22
 }

--- a/tests/docker.etest
+++ b/tests/docker.etest
@@ -30,6 +30,40 @@ setup()
     EDEBUG+=" docker"
 }
 
+mock_docker_with_context()
+{
+    etestmsg "Fake docker context"
+	cat <<-END >context
+	[
+	  {
+	    "Name": "default",
+	    "Metadata": {
+	      "StackOrchestrator": "swarm"
+	    },
+	    "Endpoints": {
+	      "docker": {
+	        "Host": "ssh://someuser@somehost:1234",
+	        "SkipTLSVerify": false
+	      }
+	    },
+	    "TLSMaterial": {},
+	    "Storage": {
+	      "MetadataPath": "<IN MEMORY>",
+	      "TLSPath": "<IN MEMORY>"
+	    }
+	  }
+	]
+	END
+    cat context
+
+    emock "docker" '
+    {
+        if [[ $1 == "context" && $2 == "inspect" ]]; then
+            cat context
+        fi
+    }'
+}
+
 ETEST_docker_build()
 {
     etestmsg "Creating Dockerfile"
@@ -1190,9 +1224,7 @@ ETEST_docker_run_passthrough_args()
 
 ETEST_docker_run_ssh_port_forward()
 {
-    export DOCKER_HOST="ssh://someuser@somehost:1234"
-
-    emock "docker"
+    mock_docker_with_context
     emock "ssh"
 
     docker_run --ssh-port-forward 8080
@@ -1203,7 +1235,7 @@ ETEST_docker_run_ssh_port_forward()
         context \
         inspect
 
-    assert_emock_called_with "docker" 2 \
+    assert_emock_called_with "docker" 1 \
         run           \
         --interactive
 
@@ -1216,37 +1248,8 @@ ETEST_docker_run_ssh_port_forward()
 
 ETEST_docker_run_ssh_port_forward_context()
 {
-    etestmsg "Fake docker context"
-	cat <<-END >context
-	[
-	  {
-	    "Name": "default",
-	    "Metadata": {
-	      "StackOrchestrator": "swarm"
-	    },
-	    "Endpoints": {
-	      "docker": {
-	        "Host": "ssh://marshall@asgard",
-	        "SkipTLSVerify": false
-	      }
-	    },
-	    "TLSMaterial": {},
-	    "Storage": {
-	      "MetadataPath": "<IN MEMORY>",
-	      "TLSPath": "<IN MEMORY>"
-	    }
-	  }
-	]
-	END
-    cat context
-
+    mock_docker_with_context
     emock "ssh"
-    emock "docker" '
-    {
-        if [[ $1 == "context" && $2 == "inspect" ]]; then
-            cat context
-        fi
-    }'
 
     docker_run --ssh-port-forward 8080
 
@@ -1269,9 +1272,7 @@ ETEST_docker_run_ssh_port_forward_context()
 
 ETEST_docker_run_ssh_port_forward_multiple()
 {
-    export DOCKER_HOST="ssh://someuser@somehost"
-
-    emock "docker"
+    mock_docker_with_context
     emock "ssh"
 
     docker_run --ssh-port-forward 8080 --ssh-port-forward 2222
@@ -1282,7 +1283,7 @@ ETEST_docker_run_ssh_port_forward_multiple()
         context \
         inspect
 
-    assert_emock_called_with "docker" 2 \
+    assert_emock_called_with "docker" 1 \
         run           \
         --interactive
 
@@ -1290,19 +1291,17 @@ ETEST_docker_run_ssh_port_forward_multiple()
     assert_emock_called_with "ssh" 0  \
         -NL                           \
         127.0.0.1:8080:127.0.0.1:8080 \
-        someuser@somehost -p 22
+        someuser@somehost -p 1234
 
     assert_emock_called_with "ssh" 1  \
         -NL                           \
         127.0.0.1:2222:127.0.0.1:2222 \
-        someuser@somehost -p 22
+        someuser@somehost -p 1234
 }
 
 ETEST_docker_run_ssh_port_forward_diff()
 {
-    export DOCKER_HOST="ssh://someuser@somehost:1234"
-
-    emock "docker"
+    mock_docker_with_context
     emock "ssh"
 
     docker_run --ssh-port-forward 80:8080
@@ -1326,9 +1325,7 @@ ETEST_docker_run_ssh_port_forward_diff()
 
 ETEST_docker_run_ssh_port_forward_diff_multiple()
 {
-    export DOCKER_HOST="ssh://someuser@somehost"
-
-    emock "docker"
+    mock_docker_with_context
     emock "ssh"
 
     docker_run --ssh-port-forward 80:8080 --ssh-port-forward 22:2222
@@ -1347,12 +1344,12 @@ ETEST_docker_run_ssh_port_forward_diff_multiple()
     assert_emock_called_with "ssh" 0 \
         -NL                          \
         127.0.0.1:80:127.0.0.1:8080  \
-        someuser@somehost -p 22
+        someuser@somehost -p 1234
 
     assert_emock_called_with "ssh" 1 \
         -NL                          \
         127.0.0.1:22:127.0.0.1:2222  \
-        someuser@somehost -p 22
+        someuser@somehost -p 1234
 }
 
 ETEST_docker_compose_run_envlist()


### PR DESCRIPTION
This adds optional SSH Port Forwarding support into ebash's provided `docker_run` and `docker_compose_run`. This will help when using a docker context that points to a remote docker server. This can be done with `docker context` or with `DOCKER_HOST` or with `DOCKER_CONTEXT`. All of this funnels down into `docker context` implementation. So we can directly query docker context to see what the host we are talking to is and see if it's a remote SSH server.

This will make it really simple in manticore I can say `docker_compose_run --ssh-port-forward 2222 --ssh-port-forward 9090` and then do an `sftp -P 2222 root@localhost`.