### PR TITLE
Immediately fail opt_parse gracefully if nullglob is enabled.

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -102,7 +102,12 @@ jobs:
           fetch-depth: 0
 
       - name: Install Dependencies
-        run: install/all
+        run: |
+            # Brew is so dumb. Trying to install git fails because both 2.35 and 2.36 are available and installing the
+            # newer one causes a symlink collision. So we just work around this be removing the old one if it is
+            # present.
+            brew unlink git@2.35.1 || true
+            install/all
 
       - name: Lint
         run: make lint

--- a/share/opt.sh
+++ b/share/opt.sh
@@ -262,6 +262,18 @@ return successfully after printing this usage statement.
 END
 opt_parse()
 {
+    # Pre-emptively check if `nullglob` has been enabled and immediately die with an error if it is enabled.
+    # This is because `nullglob` dramatically affects how bash and other GNU tools pare their option flags. As such it
+    # completely breaks `opt_parse` functionality. I tried to simply disable here in `opt_parse` but unfortunately that
+    # doesn't work.
+    if shopt -q nullglob; then
+
+        # NOTE: We can't use die() here because it requires a functional opt_parse which causes infinite recursion...
+        echo 'eval eerror "opt_parse does not work if shell option nullglob is enabled. Remove \"shopt -s nullglob\" from your code" ;'
+        echo 'exit 1'
+        exit 1
+    fi
+
     # An interesting but non-obvious trick is being played here. Opt_parse_setup is called during the opt_parse call,
     # and it sets up some variables (such as __EBASH_OPT and __EBASH_ARG). Since they're already created, when we eval
     # the calls to opt_parse_options and opt_parse_arguments, we can modify those variables and pass them amongst the

--- a/tests/opt.etest
+++ b/tests/opt.etest
@@ -39,6 +39,12 @@ ETEST_opt_parse()
     assert_eq "arg3" "$3"
 }
 
+ETEST_opt_parse_nullglob()
+{
+    shopt -s nullglob
+    assert_false ETEST_opt_parse
+}
+
 ETEST_opt_raw()
 {
     set -- -e 2 -i 10 -p 8 -v 101 -d 7 -m 9 -a 127.0.0.1 -u ebash -w ebash


### PR DESCRIPTION
This just gracefully exits immediately at the top of `opt_parse` if `nullglob` is enabled. I tried just disabling it directly, but that doesn't work at all. In any event, I really don't see a need for `nullglob` so I think it's acceptable to just bail immediately. It's sure beats the infinite recursion mess we're getting now.