### PR TITLE
Avoid need for ps in ebash.sh.

### DIFF
--- a/share/ebash.sh
+++ b/share/ebash.sh
@@ -32,7 +32,7 @@
 # gets invoked. This prevents ebash from being setup and executing properly. We solve this by simply checking if we're
 # running inside a native BASH context and if we are not, we simply execute bash directly with our script as a parameter
 # as well as any arguments we were passed.
-if [[ "$(ps -p $$ -ocomm=)" != "bash" ]]; then
+if [[ -z "${BASH:-}" ]]; then
     exec bash "$0" "${@}"
 fi
 

--- a/tests/all_depends.etest
+++ b/tests/all_depends.etest
@@ -128,6 +128,8 @@ ETEST_install_nodejs()
 
 ETEST_install_nomad()
 {
+    $(skip_if os_distro arch)
+
     local commands=(
         "nomad"
     )


### PR DESCRIPTION
Remove need for `ps` to be installed to check for BASH env.