### PR TITLE
Reimplement suite_teardown mechanism

### DIFF
--- a/share/etest/runners.sh
+++ b/share/etest/runners.sh
@@ -109,8 +109,7 @@ run_single_test()
             fi
 
             # Register __suite_teardown function as a trap callback and trigger it when the test receives an interrupt.
-            # If running the last test case, instead of triggering it by interrupt, make this function always triggered
-            # at the end of the test. 
+            # If running the last test case, instead of triggering it by interrupt, always trigger it at the end of the test. 
             if [[ ${testidx} -eq ${testidx_total} ]]; then
                 trap_add __suite_teardown EXIT
             else
@@ -143,7 +142,7 @@ run_single_test()
         {
             rc=$?
             # If failfast flag is enabled and is not running the last test case, call __suite_teardown in the catch block.
-            # Otherwise, nothing to do at here and __suite_teardown will be triggered at the end of the test.
+            # Otherwise, nothing to do here as __suite_teardown will be triggered at the end of the test.
             if [[ ${failfast} -eq 1 && ${testidx} -ne ${testidx_total} ]]; then
                 if [[ -n ${source} ]] ; then
                     source "${source}"

--- a/share/etest/runners.sh
+++ b/share/etest/runners.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 #
 # Copyright 2011-2022, Marshall McMullen <marshall.mcmullen@gmail.com>
 #
@@ -107,6 +108,9 @@ run_single_test()
                 suite_setup
             fi
 
+            # Register __suite_teardown function as a trap callback and trigger it when the test receives an interrupt.
+            # If running the last test case, instead of triggering it by interrupt, make this function always triggered
+            # at the end of the test. 
             if [[ ${testidx} -eq ${testidx_total} ]]; then
                 trap_add __suite_teardown EXIT
             else
@@ -138,6 +142,8 @@ run_single_test()
         catch
         {
             rc=$?
+            # If failfast flag is enabled and is not running the last test case, call __suite_teardown in the catch block.
+            # Otherwise, nothing to do at here and __suite_teardown will be triggered at the end of the test.
             if [[ ${failfast} -eq 1 && ${testidx} -ne ${testidx_total} ]]; then
                 if [[ -n ${source} ]] ; then
                     source "${source}"
@@ -210,6 +216,7 @@ run_single_test()
     fi
 }
 
+# A wrapper function that calls suite_teardown if it is defined by user.
 __suite_teardown()
 {
     if is_function suite_teardown; then


### PR DESCRIPTION
The current implementation of `suite_teardown` callback iscalled after `etest` runs through all test cases. However, if the `failfast` is enabled and a test case does not pass, the test aborts without calling the `suite_teardown` callback.

This PR reimplements `suite_teardown` mechanism so that it will be triggered at the end of the test, for all following scenario:
1. All tests passes
2. Some tests fails without `failfast` enabled
3. Test aborted when a test fails with failfast `enabled`
4. Test aborted by receiving an interrupt.

