### PR TITLE
Status json

### DIFF
--- a/bin/etest
+++ b/bin/etest
@@ -51,6 +51,22 @@ if [[ ${clean} -eq 1 ]]; then
     exit 0
 fi
 
+# If destroy is requested then we kill all running etest instances system-wide.
+#
+# We nominally do this using our handy cgroup containerization if available.
+# Otherwise we fall back to a more crude `pkill`.
+if [[ ${destroy} -eq 1 ]]; then
+
+    eerror "Destroying all etest instances"
+
+    if cgroup_exists "${ETEST_CGROUP_BASE}"; then
+        cgroup_kill --signal=SIGKILL ${ETEST_CGROUP_BASE}
+        cgroup_destroy --recursive ${ETEST_CGROUP_BASE}
+    else
+        pkill -9 -f etest
+    fi
+fi
+
 # Global variables for state tracking
 declare -ag TEST_FILES_TO_RUN
 declare -Ag TEST_FUNCTIONS_TO_RUN
@@ -58,8 +74,8 @@ declare -ag TEST_SUITES=()
 declare -Ag TESTS_PASSED=()
 declare -Ag TESTS_FAILED=()
 declare -Ag TESTS_FLAKY=()
-declare -Ag SUITE_RUNTIME=()
-declare -Ag TESTS_RUNTIME=()
+declare -Ag SUITE_DURATION=()
+declare -Ag TESTS_DURATION=()
 declare -g  NUM_TESTS_EXECUTED=0
 declare -g  NUM_TESTS_PASSED=0
 declare -g  NUM_TESTS_FAILED=0
@@ -71,32 +87,19 @@ declare -g  PERCENT=0
 create_test_list
 find_matching_tests
 
-# Compute total number of tests to run across all files
-for fname in "${!TEST_FUNCTIONS_TO_RUN[@]}"; do
-    array_init fname_tests "${TEST_FUNCTIONS_TO_RUN[$fname]}"
-    increment NUM_TESTS_TOTAL "${#fname_tests[@]}"
-done
-
 # If we are in print_only mode only report what we found and exit
 if [[ ${print_only} -eq 1 ]]; then
-
-    ebanner --uppercase "ETEST TESTS" OS exclude failfast filter repeat
-
-    for testname in "${TEST_FILES_TO_RUN[@]}"; do
-        einfo "${testname}"
-        echo "${TEST_FUNCTIONS_TO_RUN[$testname]:-}" | tr ' ' '\n'
-    done
-
+    print_tests
     exit 0
 fi
 
 # If we are in print_json mode only report what we found in JSON and exit
 if [[ ${print_json} -eq 1 ]]; then
-    associative_array_to_json_split TEST_FUNCTIONS_TO_RUN
+    print_tests_json
     exit 0
 fi
 
-# If total timeout is requested thn create a background process that will sleep that amount of time and then kill our
+# If total timeout is requested then create a background process that will sleep that amount of time and then kill our
 # main etest process.
 if [[ -n "${total_timeout}" && "${total_timeout}" != "infinity" ]]; then
     (
@@ -122,8 +125,10 @@ fi
 
 # Create logfile
 elogrotate "${ETEST_JSON}"
+elogrotate "${ETEST_OPTIONS_JSON}"
 elogrotate "${ETEST_XML}"
 elogfile --rotate_count=10 --tail=${verbose} ${ETEST_LOG}
+create_status_json
 
 # Run all tests the requested number of times
 for (( ITERATION=1; ITERATION<=${repeat}; ITERATION++ )); do
@@ -132,7 +137,7 @@ for (( ITERATION=1; ITERATION<=${repeat}; ITERATION++ )); do
 done
 
 # Collect and report results
-RUNTIME=$(( SECONDS - START_TIME ))
+DURATION=$(( SECONDS - START_TIME ))
 create_summary
 create_xml
 

--- a/bin/etest
+++ b/bin/etest
@@ -125,7 +125,7 @@ fi
 
 # Create logfile
 elogrotate "${ETEST_JSON}"
-elogrotate "${ETEST_OPTIONS_JSON}"
+elogrotate "${ETEST_OPTIONS}"
 elogrotate "${ETEST_XML}"
 elogfile --rotate_count=10 --tail=${verbose} ${ETEST_LOG}
 create_status_json

--- a/doc/debugging.md
+++ b/doc/debugging.md
@@ -65,4 +65,4 @@ function name. The `etrace` functionality has a much higher overhead than does r
 be immensely helpful when you really need it.
 
 One caveat: you can't change the value of `ETRACE` on the fly. The value it had when you sourced `ebash` is the one that
-will affect the entire runtime of the script.
+will affect the entire duration of the script.

--- a/share/archive.sh
+++ b/share/archive.sh
@@ -27,7 +27,7 @@ written sector on an optical disc, including the optical disc file system. The n
 - **TAR**: A tar file is an archive file format that may or may not be compressed. The archive data sets created by tar
 contain various file system parameters, such as time stamps, ownership, file access permissions, and directory
 organization. Our archive_compress_program function is used to generalize our use of tar so that compression format is
-handled seamlessly based on the file extension in a way which picks the best compression program at runtime.
+handled seamlessly based on the file extension in a way which picks the best compression program at duration.
 
 - **CPIO**: "cpio is a general file archiver utility and its associated file format. It is primarily installed on Unix-like
 computer operating systems. The software utility was originally intended as a tape archiving program as part of the

--- a/share/ebash.sh
+++ b/share/ebash.sh
@@ -101,7 +101,7 @@ for arg in "$@" ; do
     fi
 done
 
-# This function is used to create documentation for bash functions that can be queried at runtime. To avoid bloating
+# This function is used to create documentation for bash functions that can be queried at duration. To avoid bloating
 # the interpreter for this all the time, it is only performed when __EBASH_SAVE_DOC is set to 1.
 #
 # In order to create documentation for your command, do something like this near it:

--- a/share/emsg.sh
+++ b/share/emsg.sh
@@ -80,7 +80,7 @@ function name. The etrace functionality has a much higher overhead than does run
 immensely helpful when you really need it.
 
 One caveat: you can’t change the value of ETRACE on the fly. The value it had when you sourced ebash is the one that
-will affect the entire runtime of the script.
+will affect the entire duration of the script.
 END
 etrace()
 {

--- a/share/etest/results.sh
+++ b/share/etest/results.sh
@@ -65,9 +65,9 @@ create_status_json()
 	    "numTestsTotal": ${NUM_TESTS_TOTAL},
 	    "percent": ${PERCENT},
 	    "pids": $(array_to_json pids),
-	    "testsFailed": $(print_tests_json_array TESTS_FAILED),
-	    "testsFlaky": $(print_tests_json_array TESTS_FLAKY),
-	    "testsPassed": $(print_tests_json_array TESTS_PASSED)
+	    "testsFailed": $(print_tests_json_array TESTS_FAILED "    "),
+	    "testsFlaky": $(print_tests_json_array TESTS_FLAKY "    "),
+	    "testsPassed": $(print_tests_json_array TESTS_PASSED "    ")
 	}
 	EOF
 

--- a/share/etest/results.sh
+++ b/share/etest/results.sh
@@ -37,7 +37,7 @@ create_vcs_info()
 
 create_status_json()
 {
-    RUNTIME=$(( SECONDS - START_TIME ))
+    DURATION=$(( SECONDS - START_TIME ))
 
     # Compute percent complete handling corner cases with zero tests to avoid division by zero
     if [[ "${NUM_TESTS_TOTAL}" -eq 0 ]]; then
@@ -46,40 +46,57 @@ create_status_json()
         PERCENT=$((200*${NUM_TESTS_EXECUTED}/${NUM_TESTS_TOTAL} % 2 + 100*${NUM_TESTS_EXECUTED}/${NUM_TESTS_TOTAL}))
     fi
 
+    local pids=()
+    if cgroup_supported; then
+        pids=( $(cgroup_pids -r ${ETEST_CGROUP}) )
+    else
+        pids=( $(process_tree) )
+    fi
+
 	cat <<-EOF > ${ETEST_JSON}.tmp
 	{
-		"numTestsTotal": ${NUM_TESTS_TOTAL},
-		"numTestsExecuted": ${NUM_TESTS_EXECUTED},
-		"numTestsPassed": ${NUM_TESTS_PASSED},
-		"numTestsFailed": ${NUM_TESTS_FAILED},
-		"numTestsFlaky": ${NUM_TESTS_FLAKY},
-		"testsPassed": $(associative_array_to_json_split TESTS_PASSED),
-		"testsFailed": $(associative_array_to_json_split TESTS_FAILED),
-		"testsFlaky": $(associative_array_to_json_split TESTS_FLAKY),
-		"percent": ${PERCENT},
-		"runtime": "${RUNTIME} seconds",
-		"datetime": "$(etimestamp_rfc3339)",
-		"options": {
-			"clean": "${clean}",
-			"debug": "${debug}",
-			"delete": "${delete}",
-			"exclude": "${exclude}",
-			"failfast": "${failfast}",
-			"failures": "${failures}",
-			"filter": "${filter}",
-			"html": "${html}",
-			"logdir": "${logdir}",
-			"mountns": "${mountns}",
-			"repeat": "${repeat}",
-			"test_list": $(array_to_json test_list),
-			"tests": $(array_to_json tests),
-			"verbose": "${verbose}",
-			"workdir": "${workdir}"
-		}
+	    "cgroup": "${ETEST_CGROUP}",
+	    "datetime": "$(etimestamp_rfc3339)",
+	    "duration": "${DURATION}s",
+	    "numTestsExecuted": ${NUM_TESTS_EXECUTED},
+	    "numTestsFailed": ${NUM_TESTS_FAILED},
+	    "numTestsFlaky": ${NUM_TESTS_FLAKY},
+	    "numTestsPassed": ${NUM_TESTS_PASSED},
+	    "numTestsTotal": ${NUM_TESTS_TOTAL},
+	    "percent": ${PERCENT},
+	    "testsFailed": $(associative_array_to_json_split TESTS_FAILED),
+	    "testsFlaky": $(associative_array_to_json_split TESTS_FLAKY),
+	    "testsPassed": $(associative_array_to_json_split TESTS_PASSED)
 	}
 	EOF
 
     mv "${ETEST_JSON}.tmp" "${ETEST_JSON}"
+}
+
+create_options_json()
+{
+	cat <<-EOF > ${ETEST_OPTIONS}.tmp
+	{
+	    "clean": "${clean}",
+	    "debug": "${debug}",
+	    "delete": "${delete}",
+	    "exclude": "${exclude}",
+	    "failfast": "${failfast}",
+	    "failures": "${failures}",
+	    "filter": "${filter}",
+	    "html": "${html}",
+	    "logdir": "${logdir}",
+	    "mountns": "${mountns}",
+	    "repeat": "${repeat}",
+	    "silent": "${silent}",
+	    "test_list": $(array_to_json test_list),
+	    "tests": $(array_to_json tests),
+	    "verbose": "${verbose}",
+	    "workdir": "${workdir}"
+	}
+	EOF
+
+    mv "${ETEST_OPTIONS}.tmp" "${ETEST_OPTIONS}"
 }
 
 create_summary()
@@ -87,13 +104,14 @@ create_summary()
     create_vcs_info
     pack_to_json VCS_INFO > "${ETEST_VCS}"
 
+    create_options_json
     create_status_json
 
     {
         echo
         message="Finished testing $(pack_get VCS_INFO info)."
         message+=" $(( ${NUM_TESTS_PASSED} ))/${NUM_TESTS_EXECUTED} tests passed"
-        message+=" in ${RUNTIME} seconds."
+        message+=" in ${DURATION} seconds."
 
         if [[ ${NUM_TESTS_FAILED} -gt 0 ]]; then
             eerror "${message}"
@@ -135,7 +153,7 @@ create_xml()
             "$(etimestamp_rfc3339)" \
             "${NUM_TESTS_EXECUTED}" \
             "${NUM_TESTS_FAILED}"   \
-            "${RUNTIME}"
+            "${DURATION}"
 
         for suite in "${TEST_SUITES[@]}"; do
 
@@ -148,21 +166,21 @@ create_xml()
                 "${suite}"                                                      \
                 $(( ${#testcases_passed[@]} + ${#testcases_failed[@]} ))        \
                 ${#testcases_failed[@]}                                         \
-                ${SUITE_RUNTIME[$suite]}
+                ${SUITE_DURATION[$suite]}
 
             local xml_lines=()
             local name
 
             # Add all passing tests
             for name in ${testcases_passed[*]:-}; do
-                xml_lines+=( "$(printf '<testcase classname="%s" name="%s" time="%s"></testcase>\n' "${suite}" "${name}" "${TESTS_RUNTIME[$name]}")" )
+                xml_lines+=( "$(printf '<testcase classname="%s" name="%s" time="%s"></testcase>\n' "${suite}" "${name}" "${TESTS_DURATION[$name]}")" )
             done
 
             # Add all failing tests
             for name in ${testcases_failed[*]:-}; do
                 local failure_msg
                 failure_msg="$(printf '<failure message="%s:%s failed" type="ERROR"></failure>' "${suite}" "${name}")"
-                xml_lines+=( "$(printf '<testcase classname="%s" name="%s" time="%s">%s</testcase>\n' "${suite}" "${name}" "${TESTS_RUNTIME[$name]}" "${failure_msg}")" )
+                xml_lines+=( "$(printf '<testcase classname="%s" name="%s" time="%s">%s</testcase>\n' "${suite}" "${name}" "${TESTS_DURATION[$name]}" "${failure_msg}")" )
             done
 
             array_sort xml_lines

--- a/share/etest/results.sh
+++ b/share/etest/results.sh
@@ -64,9 +64,10 @@ create_status_json()
 	    "numTestsPassed": ${NUM_TESTS_PASSED},
 	    "numTestsTotal": ${NUM_TESTS_TOTAL},
 	    "percent": ${PERCENT},
-	    "testsFailed": $(associative_array_to_json_split TESTS_FAILED),
-	    "testsFlaky": $(associative_array_to_json_split TESTS_FLAKY),
-	    "testsPassed": $(associative_array_to_json_split TESTS_PASSED)
+	    "pids": $(array_to_json pids),
+	    "testsFailed": $(print_tests_json_array TESTS_FAILED),
+	    "testsFlaky": $(print_tests_json_array TESTS_FLAKY),
+	    "testsPassed": $(print_tests_json_array TESTS_PASSED)
 	}
 	EOF
 

--- a/share/etest/runners.sh
+++ b/share/etest/runners.sh
@@ -23,8 +23,8 @@ run_single_test()
 
     local rc=0
 
-    # Record start time of the test and at the end of the test we'll update the total runtime for the test. This will
-    # be total runtime including any suite setup, test setup, test teardown and suite teardown.
+    # Record start time of the test and at the end of the test we'll update the total duration for the test. This will
+    # be total duration including any suite setup, test setup, test teardown and suite teardown.
     local start_time="${SECONDS}"
 
     local display_testname=${testname}
@@ -217,8 +217,8 @@ run_single_test()
         $(tryrc -r=teardown_rc teardown)
     fi
 
-    # Finally record the total runtime of this test
-    TESTS_RUNTIME[${testname}]=$(( ${SECONDS} - ${start_time} ))
+    # Finally record the total duration of this test
+    TESTS_DURATION[${testname}]=$(( ${SECONDS} - ${start_time} ))
 
     # NOTE: If failfast is enabled don't DIE here just log the error for informational purposes and return.
     # etest already knows how to detect and report errors.
@@ -337,7 +337,7 @@ __run_all_tests_serially()
              die "Failure encountered and failfast=1" &>${ETEST_OUT}
         fi
 
-        SUITE_RUNTIME[$(basename ${testfile} .etest)]=$(( ${SECONDS} - ${suite_start_time} ))
+        SUITE_DURATION[$(basename ${testfile} .etest)]=$(( ${SECONDS} - ${suite_start_time} ))
     done
 }
 
@@ -476,8 +476,8 @@ __process_completed_jobs()
         array_remove etest_jobs_running ${pid}
 
         # Update global stats
-        TESTS_RUNTIME[${suite}]=${runtime}
-        SUITE_RUNTIME[${suite}]=$(( ${SUITE_RUNTIME[${suite}]:-0} + ${runtime} ))
+        TESTS_DURATION[${suite}]=${duration}
+        SUITE_DURATION[${suite}]=$(( ${SUITE_DURATION[${suite}]:-0} + ${duration} ))
         increment NUM_TESTS_EXECUTED ${num_tests_executed}
         increment NUM_TESTS_PASSED   ${num_tests_passed}
         increment NUM_TESTS_FAILED   ${num_tests_failed}
@@ -537,7 +537,7 @@ __spawn_new_job()
 
         # Capture suite name and start time.
         local suite=""
-        local runtime="" start_time=${SECONDS}
+        local duration="" start_time=${SECONDS}
 
         # Run the correct test runner depending on the type of file.
         if [[ "${testfile}" =~ \.etest$ ]]; then
@@ -554,7 +554,7 @@ __spawn_new_job()
             jobpath="${jobpath}"                       \
             job=$(basename "${jobpath}")               \
             rc="${NUM_TESTS_FAILED}"                   \
-            runtime=$(( ${SECONDS} - ${start_time} ))  \
+            duration=$(( ${SECONDS} - ${start_time} ))  \
             suite="${suite}"                           \
             testfile="${testfile}"                     \
             num_tests_passed="${NUM_TESTS_PASSED}"     \

--- a/share/etest/test_list.sh
+++ b/share/etest/test_list.sh
@@ -113,9 +113,8 @@ print_tests_json_array()
 
         [[ ${first} -eq 1 ]] && first=0 || echo ","
 
-        eval "entry=\${$input[$suite]:-}"
+        eval "entry=\${${input}[$suite]:-}"
         array_init tests "${entry}" " "
-
         echo "${indent}${indent}{"
         echo "${indent}${indent}${indent}\"suite\": \"$(basename ${suite%.*})\","
         echo "${indent}${indent}${indent}\"tests\": $(array_to_json tests)"

--- a/share/etest/test_list.sh
+++ b/share/etest/test_list.sh
@@ -113,7 +113,7 @@ print_tests_json_array()
 
         [[ ${first} -eq 1 ]] && first=0 || echo ","
 
-        eval "entry=\${$input}[$suite]}"
+        eval "entry=\${$input[$suite]:-}"
         array_init tests "${entry}" " "
 
         echo "${indent}${indent}{"

--- a/share/etest/test_list.sh
+++ b/share/etest/test_list.sh
@@ -93,9 +93,9 @@ print_tests()
 {
     ebanner --uppercase "ETEST TESTS" OS exclude failfast filter repeat
 
-    for testname in "${TEST_FILES_TO_RUN[@]}"; do
-        einfo "${testname}"
-        echo "${TEST_FUNCTIONS_TO_RUN[$testname]:-}" | tr ' ' '\n'
+    for suite in "${TEST_FILES_TO_RUN[@]}"; do
+        einfo "${suite}"
+        echo "${TEST_FUNCTIONS_TO_RUN[$suite]:-}" | tr ' ' '\n'
     done
 }
 
@@ -117,7 +117,7 @@ print_tests_json_array()
         array_init tests "${entry}" " "
 
         echo "${indent}${indent}{"
-        echo "${indent}${indent}${indent}\"suite\": \"$(basename ${suite%.*}}\","
+        echo "${indent}${indent}${indent}\"suite\": \"$(basename ${suite%.*})\","
         echo "${indent}${indent}${indent}\"tests\": $(array_to_json tests)"
         echo -n "${indent}${indent}}"
     done

--- a/share/etest/test_list.sh
+++ b/share/etest/test_list.sh
@@ -81,4 +81,57 @@ find_matching_tests()
             TEST_FILES_TO_RUN+=( "${testfile}" )
         fi
     done
+
+    # Compute total number of tests to run across all files
+    for fname in "${!TEST_FUNCTIONS_TO_RUN[@]}"; do
+        array_init fname_tests "${TEST_FUNCTIONS_TO_RUN[$fname]}"
+        increment NUM_TESTS_TOTAL "${#fname_tests[@]}"
+    done
+}
+
+print_tests()
+{
+    ebanner --uppercase "ETEST TESTS" OS exclude failfast filter repeat
+
+    for testname in "${TEST_FILES_TO_RUN[@]}"; do
+        einfo "${testname}"
+        echo "${TEST_FUNCTIONS_TO_RUN[$testname]:-}" | tr ' ' '\n'
+    done
+}
+
+print_tests_json_array()
+{
+    $(opt_parse \
+        "input   | Name of the associative array to convert to json array." \
+        "?indent | Amount of space to indent."                              \
+    )
+
+    echo "["
+
+    local first=1 suite tests
+    for suite in $(array_indexes_sort ${input}); do
+
+        [[ ${first} -eq 1 ]] && first=0 || echo ","
+
+        eval "entry=\${$input}[$suite]}"
+        array_init tests "${entry}" " "
+
+        echo "${indent}${indent}{"
+        echo "${indent}${indent}${indent}\"suite\": \"$(basename ${suite%.*}}\","
+        echo "${indent}${indent}${indent}\"tests\": $(array_to_json tests)"
+        echo -n "${indent}${indent}}"
+    done
+
+    echo ""
+    echo "${indent}]"
+}
+
+print_tests_json()
+{
+    echo "{"
+    echo "    \"exclude\": \"${exclude}\","
+    echo "    \"filter\": \"${filter}\","
+    echo -n "    \"suites\": "
+    print_tests_json_array TEST_FUNCTIONS_TO_RUN "    "
+    echo "}"
 }

--- a/share/opt.sh
+++ b/share/opt.sh
@@ -579,6 +579,12 @@ opt_parse_options()
                     # The value that will get assigned to this boolean option
                     local value=1
                     if [[ -n ${has_arg} ]] ; then
+                        if [[ "${opt_arg,,}" == @(t|true) ]]; then
+                            opt_arg=1
+                        elif [[ "${opt_arg,,}" == @(f|false) ]]; then
+                            opt_arg=0
+                        fi
+
                         value=${opt_arg}
                     fi
 

--- a/tests/etest/options/config_file.etest
+++ b/tests/etest/options/config_file.etest
@@ -132,7 +132,7 @@ ETEST_options_config_file_prefer_newer_workdir()
 }
 
 # Runtime options override both config file settings
-ETEST_options_config_file_prefer_runtime_options()
+ETEST_options_config_file_prefer_duration_options()
 {
     etestmsg "Creating config file"
 	cat >.ebash <<- 'END'

--- a/tests/etest/results/summary.etest
+++ b/tests/etest/results/summary.etest
@@ -32,7 +32,7 @@ ETEST_results_summary_passed()
     NUM_TESTS_PASSED=5 TESTS_PASSED=( [suite]="test1 test2 test3 test4 test5" )
     NUM_TESTS_FAILED=0 TESTS_FAILED=()
     NUM_TESTS_FLAKY=0  TESTS_FLAKY=()
-    RUNTIME="${SECONDS}"
+    DURATION="${SECONDS}"
 
     etestmsg "Calling create_summary"
     create_summary
@@ -44,7 +44,7 @@ ETEST_results_summary_passed()
     [[ -s "${ETEST_JSON}" ]]
 
     etestmsg "Checking log file"
-    grep -q "Finished testing $(pack_get VCS_INFO info). 5/5 tests passed in ${RUNTIME} seconds." "${ETEST_LOG}"
+    grep -q "Finished testing $(pack_get VCS_INFO info). 5/5 tests passed in ${DURATION} seconds." "${ETEST_LOG}"
     assert_false grep "FAILED TESTS:" "${ETEST_LOG}"
     assert_false grep "FLAKY TESTS:"  "${ETEST_LOG}"
 
@@ -55,7 +55,7 @@ ETEST_results_summary_passed()
     assert_eq 5 "${numTestsPassed}"
     assert_eq 0 "${numTestsFailed}"
     assert_eq 0 "${numTestsFlaky}"
-    assert_eq "${RUNTIME} seconds" "${runtime}"
+    assert_eq "${DURATION} seconds" "${duration}"
 
     etestmsg "Checking test suite results in json file"
     assert_eq '{"suite":["test1","test2","test3","test4","test5"]}' "${testsPassed[*]}"
@@ -69,7 +69,7 @@ ETEST_results_summary_failed()
     NUM_TESTS_PASSED=0 TESTS_PASSED=()
     NUM_TESTS_FAILED=5 TESTS_FAILED=( [suite]="test1 test2 test3 test4 test5" )
     NUM_TESTS_FLAKY=0  TESTS_FLAKY=()
-    RUNTIME="${SECONDS}"
+    DURATION="${SECONDS}"
 
     etestmsg "Calling create_summary"
     create_summary
@@ -84,7 +84,7 @@ ETEST_results_summary_failed()
     noansi "${ETEST_LOG}"
     cat "${ETEST_LOG}" | edebug
 
-    grep -q "Finished testing $(pack_get VCS_INFO info). 0/5 tests passed in ${RUNTIME} seconds." "${ETEST_LOG}"
+    grep -q "Finished testing $(pack_get VCS_INFO info). 0/5 tests passed in ${DURATION} seconds." "${ETEST_LOG}"
 
     grep -Poz 'FAILED TESTS:\n\s*test1\n\s*test2\n\s*test3\n\s*test4\n\s*test5' "${ETEST_LOG}"
     echo
@@ -98,7 +98,7 @@ ETEST_results_summary_failed()
     assert_eq 0 "${numTestsPassed}"
     assert_eq 5 "${numTestsFailed}"
     assert_eq 0 "${numTestsFlaky}"
-    assert_eq "${RUNTIME} seconds" "${runtime}"
+    assert_eq "${DURATION} seconds" "${duration}"
 
     etestmsg "Checking test suite results in json file"
     assert_eq '{}' "${testsPassed[*]}"
@@ -112,7 +112,7 @@ ETEST_results_summary_mixed()
     NUM_TESTS_PASSED=3 TESTS_PASSED=( [suite]="test1 test3 test5" )
     NUM_TESTS_FAILED=1 TESTS_FAILED=( [suite]="test2" )
     NUM_TESTS_FLAKY=1  TESTS_FLAKY=( [suite]="test4" )
-    RUNTIME="${SECONDS}"
+    DURATION="${SECONDS}"
 
     etestmsg "Calling create_summary"
     create_summary
@@ -127,7 +127,7 @@ ETEST_results_summary_mixed()
     noansi "${ETEST_LOG}"
     cat "${ETEST_LOG}" | edebug
 
-    grep -q "Finished testing $(pack_get VCS_INFO info). 3/5 tests passed in ${RUNTIME} seconds." "${ETEST_LOG}"
+    grep -q "Finished testing $(pack_get VCS_INFO info). 3/5 tests passed in ${DURATION} seconds." "${ETEST_LOG}"
 
     grep -Poz 'FAILED TESTS:\n\s*test2' "${ETEST_LOG}"
     echo
@@ -142,7 +142,7 @@ ETEST_results_summary_mixed()
     assert_eq 3 "${numTestsPassed}"
     assert_eq 1 "${numTestsFailed}"
     assert_eq 1 "${numTestsFlaky}"
-    assert_eq "${RUNTIME} seconds" "${runtime}"
+    assert_eq "${DURATION} seconds" "${duration}"
 
     etestmsg "Checking test suite results in json file"
     assert_eq '{"suite":["test1","test3","test5"]}' "${testsPassed[*]}"

--- a/tests/etest/results/summary.etest
+++ b/tests/etest/results/summary.etest
@@ -55,7 +55,7 @@ ETEST_results_summary_passed()
     assert_eq 5 "${numTestsPassed}"
     assert_eq 0 "${numTestsFailed}"
     assert_eq 0 "${numTestsFlaky}"
-    assert_eq "${DURATION} seconds" "${duration}"
+    assert_eq "${DURATION}s" "${duration}"
 
     etestmsg "Checking test suite results in json file"
     assert_eq '{"suite":["test1","test2","test3","test4","test5"]}' "${testsPassed[*]}"
@@ -98,7 +98,7 @@ ETEST_results_summary_failed()
     assert_eq 0 "${numTestsPassed}"
     assert_eq 5 "${numTestsFailed}"
     assert_eq 0 "${numTestsFlaky}"
-    assert_eq "${DURATION} seconds" "${duration}"
+    assert_eq "${DURATION}s" "${duration}"
 
     etestmsg "Checking test suite results in json file"
     assert_eq '{}' "${testsPassed[*]}"
@@ -142,7 +142,7 @@ ETEST_results_summary_mixed()
     assert_eq 3 "${numTestsPassed}"
     assert_eq 1 "${numTestsFailed}"
     assert_eq 1 "${numTestsFlaky}"
-    assert_eq "${DURATION} seconds" "${duration}"
+    assert_eq "${DURATION}s" "${duration}"
 
     etestmsg "Checking test suite results in json file"
     assert_eq '{"suite":["test1","test3","test5"]}' "${testsPassed[*]}"

--- a/tests/etest/results/summary.etest
+++ b/tests/etest/results/summary.etest
@@ -58,9 +58,12 @@ ETEST_results_summary_passed()
     assert_eq "${DURATION}s" "${duration}"
 
     etestmsg "Checking test suite results in json file"
-    assert_eq '{"suite":["test1","test2","test3","test4","test5"]}' "${testsPassed[*]}"
-    assert_eq '{}' "${testsFailed[*]}"
-    assert_eq '{}' "${testsFlaky[*]}"
+    testsPassed="$(jq -r .testsPassed "${ETEST_JSON}" | tr -d '\n' | tr -d ' ')"
+    assert_eq '[{"suite":"suite","tests":["test1","test2","test3","test4","test5"]}]' "${testsPassed}"
+    testsFailed="$(jq -r .testsFailed "${ETEST_JSON}" | tr -d '\n' | tr -d ' ')"
+    assert_eq '[]' "${testsFailed}"
+    testsFlaky="$(jq -r  .testsFlaky  "${ETEST_JSON}" | tr -d '\n' | tr -d ' ')"
+    assert_eq '[]' "${testsFlaky}"
 }
 
 ETEST_results_summary_failed()
@@ -82,7 +85,6 @@ ETEST_results_summary_failed()
 
     etestmsg "Checking log file"
     noansi "${ETEST_LOG}"
-    cat "${ETEST_LOG}" | edebug
 
     grep -q "Finished testing $(pack_get VCS_INFO info). 0/5 tests passed in ${DURATION} seconds." "${ETEST_LOG}"
 
@@ -100,10 +102,14 @@ ETEST_results_summary_failed()
     assert_eq 0 "${numTestsFlaky}"
     assert_eq "${DURATION}s" "${duration}"
 
+
     etestmsg "Checking test suite results in json file"
-    assert_eq '{}' "${testsPassed[*]}"
-    assert_eq '{"suite":["test1","test2","test3","test4","test5"]}' "${testsFailed[*]}"
-    assert_eq '{}' "${testsFlaky[*]}"
+    testsPassed="$(jq -r .testsPassed "${ETEST_JSON}" | tr -d '\n' | tr -d ' ')"
+    assert_eq '[]' "${testsPassed}"
+    testsFailed="$(jq -r .testsFailed "${ETEST_JSON}" | tr -d '\n' | tr -d ' ')"
+    assert_eq '[{"suite":"suite","tests":["test1","test2","test3","test4","test5"]}]' "${testsFailed}"
+    testsFlaky="$(jq -r  .testsFlaky  "${ETEST_JSON}" | tr -d '\n' | tr -d ' ')"
+    assert_eq '[]' "${testsFlaky}"
 }
 
 ETEST_results_summary_mixed()
@@ -125,7 +131,6 @@ ETEST_results_summary_mixed()
 
     etestmsg "Checking log file"
     noansi "${ETEST_LOG}"
-    cat "${ETEST_LOG}" | edebug
 
     grep -q "Finished testing $(pack_get VCS_INFO info). 3/5 tests passed in ${DURATION} seconds." "${ETEST_LOG}"
 
@@ -137,6 +142,7 @@ ETEST_results_summary_mixed()
 
     etestmsg "Checking json file"
     jq . "${ETEST_JSON}"
+
     $(json_import --file "${ETEST_JSON}")
     assert_eq 5 "${numTestsExecuted}"
     assert_eq 3 "${numTestsPassed}"
@@ -145,7 +151,10 @@ ETEST_results_summary_mixed()
     assert_eq "${DURATION}s" "${duration}"
 
     etestmsg "Checking test suite results in json file"
-    assert_eq '{"suite":["test1","test3","test5"]}' "${testsPassed[*]}"
-    assert_eq '{"suite":["test2"]}' "${testsFailed[*]}"
-    assert_eq '{"suite":["test4"]}' "${testsFlaky[*]}"
+    testsPassed="$(jq -r .testsPassed "${ETEST_JSON}" | tr -d '\n' | tr -d ' ')"
+    assert_eq '[{"suite":"suite","tests":["test1","test3","test5"]}]' "${testsPassed}"
+    testsFailed="$(jq -r .testsFailed "${ETEST_JSON}" | tr -d '\n' | tr -d ' ')"
+    assert_eq '[{"suite":"suite","tests":["test2"]}]' "${testsFailed}"
+    testsFlaky="$(jq -r  .testsFlaky  "${ETEST_JSON}" | tr -d '\n' | tr -d ' ')"
+    assert_eq '[{"suite":"suite","tests":["test4"]}]' "${testsFlaky}"
 }


### PR DESCRIPTION
A number of improvements to etest:

1. Create a `status.json` file in the logdir that gets updated after every test. This includes useful things like percent complete, failed tests, etc.
2. Add new `--destroy` flag to etest to make it easier to aggressively kill all etest instances on the system.
3. Add new `--silent` flag to make etest totally silent (as much as possible)
4. Create new `options.json` file in logdir with the options used on that test iteration.
5. 